### PR TITLE
MethodImpl→凾

### DIFF
--- a/Competitive.Library/Bit/Bit.cs
+++ b/Competitive.Library/Bit/Bit.cs
@@ -2,65 +2,72 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class Bit
     {
         /// <summary>
         /// <paramref name="num"/> を長さ <paramref name="padLeft"/> の 2 進数文字列にします。
         /// </summary>
+        [凾(256)]
         public static string ToBitString(this int num, int padLeft = sizeof(int) * 8) => Convert.ToString(num, 2).PadLeft(padLeft, '0');
         /// <summary>
         /// <paramref name="num"/> を長さ <paramref name="padLeft"/> の 2 進数文字列にします。
         /// </summary>
+        [凾(256)]
         public static string ToBitString(this uint num, int padLeft = sizeof(uint) * 8) => Convert.ToString((int)num, 2).PadLeft(padLeft, '0');
         /// <summary>
         /// <paramref name="num"/> を長さ <paramref name="padLeft"/> の 2 進数文字列にします。
         /// </summary>
+        [凾(256)]
         public static string ToBitString(this long num, int padLeft = sizeof(long) * 8) => Convert.ToString(num, 2).PadLeft(padLeft, '0');
         /// <summary>
         /// <paramref name="num"/> を長さ <paramref name="padLeft"/> の 2 進数文字列にします。
         /// </summary>
+        [凾(256)]
         public static string ToBitString(this ulong num, int padLeft = sizeof(ulong) * 8) => Convert.ToString(unchecked((long)num), 2).PadLeft(padLeft, '0');
         /// <summary>
         /// <paramref name="num"/> の <paramref name="index"/> 番目のビットが立っているかを返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool On(this int num, int index) => ((num >> index) & 1) != 0;
         /// <summary>
         /// <paramref name="num"/> の <paramref name="index"/> 番目のビットが立っているかを返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool On(this uint num, int index) => ((num >> index) & 1) != 0;
         /// <summary>
         /// <paramref name="num"/> の <paramref name="index"/> 番目のビットが立っているかを返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool On(this long num, int index) => ((num >> index) & 1) != 0;
         /// <summary>
         /// <paramref name="num"/> の <paramref name="index"/> 番目のビットが立っているかを返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool On(this ulong num, int index) => ((num >> index) & 1) != 0;
         /// <summary>
         /// <paramref name="num"/> の立っているビットを列挙します。
         /// </summary>
+        [凾(256)]
         public static Enumerator Bits(this int num) => new Enumerator(num);
         /// <summary>
         /// <paramref name="num"/> の立っているビットを列挙します。
         /// </summary>
+        [凾(256)]
         public static Enumerator Bits(this uint num) => new Enumerator(num);
         /// <summary>
         /// <paramref name="num"/> の立っているビットを列挙します。
         /// </summary>
+        [凾(256)]
         public static Enumerator Bits(this long num) => new Enumerator(num);
         /// <summary>
         /// <paramref name="num"/> の立っているビットを列挙します。
         /// </summary>
+        [凾(256)]
         public static Enumerator Bits(this ulong num) => new Enumerator(num);
         public struct Enumerator : IEnumerable<int>, IEnumerator<int>
         {
@@ -70,7 +77,7 @@ namespace Kzrnm.Competitive
             public Enumerator(ulong num) { this.num = num; Current = -1; }
             public Enumerator GetEnumerator() => this;
             public int Current { get; private set; }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool MoveNext()
             {
                 if (num == 0) return false;

--- a/Competitive.Library/Collection/PriorityQueue.cs
+++ b/Competitive.Library/Collection/PriorityQueue.cs
@@ -1,48 +1,75 @@
 ﻿using AtCoder.Internal;
 using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class PriorityQueue
     {
+
+        [凾(256)]
         public static PriorityQueueOp<T, DefaultComparerStruct<T>> Create<T>()
             where T : IComparable<T>
             => new PriorityQueueOp<T, DefaultComparerStruct<T>>();
+
+        [凾(256)]
         public static PriorityQueueOp<T, DefaultComparerStruct<T>> Create<T>(int capacity)
             where T : IComparable<T>
             => new PriorityQueueOp<T, DefaultComparerStruct<T>>(capacity);
+
+        [凾(256)]
         public static PriorityQueueOp<T, TOp> Create<T, TOp>()
             where TOp : struct, IComparer<T>
             => new PriorityQueueOp<T, TOp>(default(TOp));
+
+        [凾(256)]
         public static PriorityQueueOp<T, TOp> Create<T, TOp>(TOp comparer)
             where TOp : IComparer<T>
             => new PriorityQueueOp<T, TOp>(comparer);
+
+        [凾(256)]
         public static PriorityQueueOp<T, TOp> Create<T, TOp>(int capacity)
             where TOp : IComparer<T>
             => new PriorityQueueOp<T, TOp>(capacity, default(TOp));
+
+        [凾(256)]
         public static PriorityQueueOp<T, TOp> Create<T, TOp>(int capacity, TOp comparer)
             where TOp : IComparer<T>
             => new PriorityQueueOp<T, TOp>(capacity, comparer);
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, DefaultComparerStruct<TKey>> CreateDictionary<TKey, TValue>()
             where TKey : IComparable<TKey>
             => new PriorityQueueOp<TKey, TValue, DefaultComparerStruct<TKey>>();
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, DefaultComparerStruct<TKey>> CreateDictionary<TKey, TValue>(int capacity)
             where TKey : IComparable<TKey>
             => new PriorityQueueOp<TKey, TValue, DefaultComparerStruct<TKey>>(capacity);
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, TOp> CreateDictionary<TKey, TValue, TOp>()
             where TOp : struct, IComparer<TKey>
             => new PriorityQueueOp<TKey, TValue, TOp>(default(TOp));
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, TOp> CreateDictionary<TKey, TValue, TOp>(TOp comparer)
             where TOp : IComparer<TKey>
             => new PriorityQueueOp<TKey, TValue, TOp>(comparer);
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, TOp> CreateDictionary<TKey, TValue, TOp>(int capacity)
             where TOp : IComparer<TKey>
             => new PriorityQueueOp<TKey, TValue, TOp>(capacity, default(TOp));
+
+        [凾(256)]
         public static PriorityQueueOp<TKey, TValue, TOp> CreateDictionary<TKey, TValue, TOp>(int capacity, TOp comparer)
             where TOp : IComparer<TKey>
             => new PriorityQueueOp<TKey, TValue, TOp>(capacity, comparer);
 
+
+        [凾(256)]
         public static bool TryDequeue<TKey, T, TKOp>(this PriorityQueueOp<TKey, (T, T), TKOp> pq, out TKey key, out T Item1, out T Item2) where TKOp : IComparer<TKey>
         {
             var result = pq.TryDequeue(out key, out var tuple);

--- a/Competitive.Library/Collection/PriorityQueueDijkstra.cs
+++ b/Competitive.Library/Collection/PriorityQueueDijkstra.cs
@@ -3,12 +3,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     [DebuggerTypeProxy(typeof(PriorityQueueDijkstra<,>.DebugView))]
     [DebuggerDisplay(nameof(Count) + " = {" + nameof(Count) + "}")]
     public class PriorityQueueDijkstra<TKey, TKOp> : IPriorityQueueOp<KeyValuePair<TKey, int>>
@@ -32,9 +30,9 @@ namespace Kzrnm.Competitive
         public int Count { get; private set; } = 0;
 
         public KeyValuePair<TKey, int> Peek => KeyValuePair.Create(keys[0], values[0]);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         void IPriorityQueueOp<KeyValuePair<TKey, int>>.Enqueue(KeyValuePair<TKey, int> pair) => Enqueue(pair.Key, pair.Value);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public void Enqueue(TKey key, int value)
         {
             var ix = indexes[value];
@@ -46,7 +44,7 @@ namespace Kzrnm.Competitive
             keys[ix] = key;
             UpdateUp(ix);
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool TryDequeue(out TKey key, out int value)
         {
             if (Count == 0)
@@ -58,7 +56,7 @@ namespace Kzrnm.Competitive
             (key, value) = Dequeue();
             return true;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool TryDequeue(out KeyValuePair<TKey, int> result)
         {
             if (Count == 0)
@@ -69,7 +67,7 @@ namespace Kzrnm.Competitive
             result = Dequeue();
             return true;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public KeyValuePair<TKey, int> Dequeue()
         {
             indexes[values[0]] = -1;
@@ -80,7 +78,7 @@ namespace Kzrnm.Competitive
             UpdateDown(0);
             return res;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private void UpdateUp(int i)
         {
             var tar = keys[i];
@@ -99,7 +97,7 @@ namespace Kzrnm.Competitive
             values[i] = tarVal;
             indexes[values[i]] = i;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private void UpdateDown(int i)
         {
             var tar = keys[i];

--- a/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.Enumerator.cs
+++ b/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.Enumerator.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -50,6 +51,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             public T Current
             {
+                [凾(256)]
                 get
                 {
                     if (_remainingForwardsStack == null)
@@ -78,6 +80,7 @@ namespace Kzrnm.Competitive
             /// Advances enumeration to the next element.
             /// </summary>
             /// <returns>A value indicating whether there is another element in the enumeration.</returns>
+            [凾(256)]
             public bool MoveNext()
             {
                 if (_remainingForwardsStack == null)
@@ -140,9 +143,10 @@ namespace Kzrnm.Competitive
             /// </summary>
             public T Current
             {
+                [凾(256)]
                 get
                 {
-                    this.ThrowIfDisposed();
+                    ThrowIfDisposed();
                     if (_remainingForwardsStack == null)
                     {
                         // The initial call to MoveNext has not yet been made.
@@ -177,6 +181,7 @@ namespace Kzrnm.Competitive
             /// Advances enumeration to the next element.
             /// </summary>
             /// <returns>A value indicating whether there is another element in the enumeration.</returns>
+            [凾(256)]
             public bool MoveNext()
             {
                 this.ThrowIfDisposed();

--- a/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.LazyStack.Enumerator.cs
+++ b/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.LazyStack.Enumerator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -41,6 +42,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             public T Current
             {
+                [凾(256)]
                 get
                 {
                     if (_remainingStack == null || _remainingStack.IsEmpty)
@@ -58,6 +60,7 @@ namespace Kzrnm.Competitive
             /// Moves to the first or next element.
             /// </summary>
             /// <returns>A value indicating whether there are any more elements.</returns>
+            [凾(256)]
             public bool MoveNext()
             {
                 if (_remainingStack == null)
@@ -109,6 +112,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             public T Current
             {
+                [凾(256)]
                 get
                 {
                     this.ThrowIfDisposed();
@@ -136,6 +140,7 @@ namespace Kzrnm.Competitive
             /// Moves to the first or next element.
             /// </summary>
             /// <returns>A value indicating whether there are any more elements.</returns>
+            [凾(256)]
             public bool MoveNext()
             {
                 this.ThrowIfDisposed();

--- a/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.LazyStack.cs
+++ b/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.LazyStack.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -88,6 +89,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             public static LazyStack Empty
             {
+                [凾(256)]
                 get
                 {
                     Debug.Assert(s_EmptyField.IsEmpty);
@@ -98,6 +100,7 @@ namespace Kzrnm.Competitive
             /// <summary>
             /// Gets the empty stack, upon which all stacks are built.
             /// </summary>
+            [凾(256)]
             public LazyStack Clear()
             {
                 Debug.Assert(s_EmptyField.IsEmpty);
@@ -120,6 +123,7 @@ namespace Kzrnm.Competitive
             /// </value>
             public bool IsEmpty
             {
+                [凾(256)]
                 get
                 {
                     return _tail is null && _lazySchedule is null;
@@ -133,6 +137,7 @@ namespace Kzrnm.Competitive
             /// The element on the top of the stack.
             /// </returns>
             /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            [凾(256)]
             public T Peek()
             {
                 AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -151,6 +156,7 @@ namespace Kzrnm.Competitive
             /// A read-only reference to the element on the top of the stack.
             /// </returns>
             /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            [凾(256)]
             public ref readonly T PeekRef()
             {
                 AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -168,6 +174,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             /// <param name="value">The element to push onto the stack.</param>
             /// <returns>The new stack.</returns>
+            [凾(256)]
             public LazyStack Push(T value)
             {
                 return new LazyStack(value, this);
@@ -188,6 +195,7 @@ namespace Kzrnm.Competitive
             /// </summary>
             /// <returns>A stack; never <c>null</c></returns>
             /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            [凾(256)]
             public LazyStack Pop()
             {
                 AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -217,6 +225,7 @@ namespace Kzrnm.Competitive
             /// <returns>
             /// A stack; never <c>null</c>
             /// </returns>
+            [凾(256)]
             public LazyStack Pop(out T value)
             {
                 if (_tail is null && _lazySchedule is { })
@@ -227,6 +236,7 @@ namespace Kzrnm.Competitive
                 return this.Pop();
             }
 
+            [凾(256)]
             internal void Rotate()
             {
                 Debug.Assert(_lazyHeads is { });

--- a/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.cs
+++ b/Competitive.Library/Collection/RealTimeQueue/RealTimeQueue_1.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -68,6 +69,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             _backwards = backwards;
             _lazy = lazy;
         }
+        [凾(256)]
         internal static RealTimeQueue<T> Create(LazyStack forwards, ImmutableStack<T> backwards, LazyStack lazy)
         {
             if (!lazy.IsEmpty)
@@ -160,6 +162,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// Gets the element at the front of the queue.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">Thrown when the queue is empty.</exception>
+        [凾(256)]
         public T Peek()
         {
             AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -171,6 +174,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// Gets a read-only reference to the element at the front of the queue.
         /// </summary>
         /// <exception cref="System.InvalidOperationException">Thrown when the queue is empty.</exception>
+        [凾(256)]
         public ref readonly T PeekRef()
         {
             AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -185,6 +189,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// <returns>
         /// The new queue.
         /// </returns>
+        [凾(256)]
         public RealTimeQueue<T> Enqueue(T value)
         {
             return Create(_forwards, _backwards.Push(value), _lazy);
@@ -207,6 +212,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// </summary>
         /// <returns>A queue; never <c>null</c>.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the queue is empty.</exception>
+        [凾(256)]
         public RealTimeQueue<T> Dequeue()
         {
             AtCoder.Internal.Contract.Assert(!IsEmpty, "This operation does not apply to an empty instance.");
@@ -224,6 +230,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// <param name="value">Receives the value from the head of the queue.</param>
         /// <returns>The new queue with the head element removed.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the queue is empty.</exception>
+        [凾(256)]
         public RealTimeQueue<T> Dequeue(out T value)
         {
             value = this.Peek();

--- a/Competitive.Library/Collection/Set/Set.cs
+++ b/Competitive.Library/Collection/Set/Set.cs
@@ -3,11 +3,10 @@ using Kzrnm.Competitive.SetInternals;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     [DebuggerTypeProxy(typeof(CollectionDebugView<>))]
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
     public class Set<T> : Set<T, DefaultComparerStruct<T>>
@@ -50,19 +49,19 @@ namespace Kzrnm.Competitive
             {
                 this.comparer = comparer;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public Node Create(T item, NodeColor color) => new Node(item, color);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T GetValue(Node node) => node.Item;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void SetValue(ref Node node, T value) => node.Item = value;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T GetCompareKey(T item) => item;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T x, T y) => comparer.Compare(x, y);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(Node node1, Node node2) => comparer.Compare(node1.Item, node2.Item);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T value, Node node) => comparer.Compare(value, node.Item);
         }
     }

--- a/Competitive.Library/Collection/Set/SetBase.cs
+++ b/Competitive.Library/Collection/Set/SetBase.cs
@@ -7,10 +7,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive.SetInternals
 {
-    using static MethodImplOptions;
     public interface ISetOperator<T, TCmp, Node> : IComparer<TCmp>
     {
         Node Create(T item, NodeColor color);
@@ -51,25 +51,25 @@ namespace Kzrnm.Competitive.SetInternals
     public struct SetLowerBoundOperator : ISetBinarySearchOperator
     {
         public bool ReturnLeft => false;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool IntoLeft(int order) => order <= 0;
     }
     public struct SetUpperBoundOperator : ISetBinarySearchOperator
     {
         public bool ReturnLeft => false;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool IntoLeft(int order) => order < 0;
     }
     public struct SetLowerBoundReverseOperator : ISetBinarySearchOperator
     {
         public bool ReturnLeft => true;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool IntoLeft(int order) => order < 0;
     }
     public struct SetUpperBoundReverseOperator : ISetBinarySearchOperator
     {
         public bool ReturnLeft => true;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool IntoLeft(int order) => order <= 0;
     }
 
@@ -181,6 +181,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             return root;
         }
         #endregion Constructor
+        [凾(256)]
         internal Node MinNode()
         {
             if (root == null) return null;
@@ -188,6 +189,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             while (cur.Left != null) { cur = cur.Left; }
             return cur;
         }
+        [凾(256)]
         internal Node MaxNode()
         {
             if (root == null) return null;
@@ -199,6 +201,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         public T Max => MaxNode() switch { { } n => op.GetValue(n), _ => default(T) };
 
         #region Search
+        [凾(256)]
         public Node FindNode(TCmp item)
         {
             Node current = root;
@@ -211,6 +214,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             return null;
         }
 
+        [凾(256)]
         public int Index(Node node)
         {
             var _node = node;
@@ -229,6 +233,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             return ret;
         }
 
+        [凾(256)]
         public Node FindByIndex(int index)
         {
             var current = root;
@@ -256,8 +261,9 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// </summary>
         /// <param name="item">検索する要素</param>
         /// <param name="bop">二分探索の判定オペレーター</param>
+        [凾(256)]
         public (Node node, int index) BinarySearch<TBOp>(TCmp item, TBOp bop = default)
-            where TBOp : struct, ISetBinarySearchOperator
+               where TBOp : struct, ISetBinarySearchOperator
         {
             Node left = null, right = null;
             Node current = root;
@@ -291,56 +297,69 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// <summary>
         /// <paramref name="item"/> 以上の最初のノードを返します。
         /// </summary>
+        [凾(256)]
         public Node FindNodeLowerBound(TCmp item) => BinarySearch<SetLowerBoundOperator>(item).node;
         /// <summary>
         /// <paramref name="item"/> 以上の最初のインデックスを返します。
         /// </summary>
+        [凾(256)]
         public int LowerBoundIndex(TCmp item) => BinarySearch<SetLowerBoundOperator>(item).index;
         /// <summary>
         /// <paramref name="item"/> 以上の最初の要素を返します。
         /// </summary>
+        [凾(256)]
         public T LowerBoundItem(TCmp item) => op.GetValue(BinarySearch<SetLowerBoundOperator>(item).node);
         /// <summary>
         /// <paramref name="item"/> を超える最初のノードを返します。
         /// </summary>
+        [凾(256)]
         public Node FindNodeUpperBound(TCmp item) => BinarySearch<SetUpperBoundOperator>(item).node;
         /// <summary>
         /// <paramref name="item"/> を超える最初のインデックスを返します。
         /// </summary>
+        [凾(256)]
         public int UpperBoundIndex(TCmp item) => BinarySearch<SetUpperBoundOperator>(item).index;
         /// <summary>
         /// <paramref name="item"/> を超える最初の要素を返します。
         /// </summary>
+        [凾(256)]
         public T UpperBoundItem(TCmp item) => op.GetValue(BinarySearch<SetUpperBoundOperator>(item).node);
 
         /// <summary>
         /// <paramref name="item"/> 以下の最後のノードを返します。
         /// </summary>
+        [凾(256)]
         public Node FindNodeReverseLowerBound(TCmp item) => BinarySearch<SetLowerBoundReverseOperator>(item).node;
         /// <summary>
         /// <paramref name="item"/> 以下の最後のインデックスを返します。
         /// </summary>
+        [凾(256)]
         public int ReverseLowerBoundIndex(TCmp item) => BinarySearch<SetLowerBoundReverseOperator>(item).index;
         /// <summary>
         /// <paramref name="item"/> 以下の最後の要素を返します。
         /// </summary>
+        [凾(256)]
         public T ReverseLowerBoundItem(TCmp item) => op.GetValue(BinarySearch<SetLowerBoundReverseOperator>(item).node);
 
         /// <summary>
         /// <paramref name="item"/> 未満の最後のノードを返します。
         /// </summary>
+        [凾(256)]
         public Node FindNodeReverseUpperBound(TCmp item) => BinarySearch<SetUpperBoundReverseOperator>(item).node;
         /// <summary>
         /// <paramref name="item"/> 未満の最後のインデックスを返します。
         /// </summary>
+        [凾(256)]
         public int ReverseUpperBoundIndex(TCmp item) => BinarySearch<SetUpperBoundReverseOperator>(item).index;
         /// <summary>
         /// <paramref name="item"/> 未満の最後の要素を返します。
         /// </summary>
+        [凾(256)]
         public T ReverseUpperBoundItem(TCmp item) => op.GetValue(BinarySearch<SetUpperBoundReverseOperator>(item).node);
         #endregion Search
 
         #region Enumerate
+        [凾(256)]
         public IEnumerable<T> Reversed()
         {
             var e = new ValueEnumerator(this, true, null);
@@ -353,6 +372,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// <param name="from">列挙開始するノードの値</param>
         /// <param name="reverse">以上ではなく以下を列挙する</param>
         /// <returns></returns>
+        [凾(256)]
         public IEnumerable<T> EnumerateItem(Node from = null, bool reverse = false)
         {
             var e = new ValueEnumerator(this, reverse, from);
@@ -364,6 +384,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         /// <param name="from">列挙開始するノードの値</param>
         /// <param name="reverse">以上ではなく以下を列挙する</param>
         /// <returns></returns>
+        [凾(256)]
         public IEnumerable<Node> EnumerateNode(Node from = null, bool reverse = false)
         {
             var e = new Enumerator(this, reverse, from);
@@ -374,6 +395,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         #region ICollection<T> members
         void ICollection<T>.Add(T item) => DoAdd(item);
 
+        [凾(256)]
         public bool Add(T item) => DoAdd(item);
         protected bool DoAdd(T item)
         {
@@ -489,6 +511,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             root?.ColorBlack();
         }
         bool ICollection<T>.Remove(T item) => Remove(op.GetCompareKey(item));
+        [凾(256)]
         public bool Remove(TCmp item) => DoRemove(item);
         protected bool DoRemove(TCmp item)
         {
@@ -557,6 +580,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             ReplaceChildOrRoot(greatGrandParent, grandParent, newChildOfGreatGrandParent);
 
         }
+        [凾(256)]
         protected void ReplaceChildOrRoot(Node parent, Node child, Node newChild)
         {
             if (parent != null)
@@ -567,6 +591,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 if (root != null) root.Parent = null;
             }
         }
+        [凾(256)]
         protected void ReplaceNode(Node match, Node parentOfMatch, Node successor, Node parentOfSuccessor)
         {
             Debug.Assert(match != null);
@@ -602,10 +627,11 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         object ICollection.SyncRoot => this;
         public int Count => NodeSize(root);
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal static int NodeSize(Node node) => node == null ? 0 : node.Size;
 
 
+        [凾(256)]
         public ValueEnumerator GetEnumerator() => new ValueEnumerator(this);
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => new ValueEnumerator(this);
         IEnumerator IEnumerable.GetEnumerator() => new ValueEnumerator(this);
@@ -629,6 +655,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 else Intialize(startNode);
 
             }
+            [凾(256)]
             void IntializeAll()
             {
                 var node = tree.root;
@@ -639,6 +666,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                     node = next;
                 }
             }
+            [凾(256)]
             void Intialize(Node startNode)
             {
                 if (startNode == null)
@@ -649,6 +677,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 list.Reverse();
                 foreach (var n in list) stack.Push(n);
             }
+            [凾(256)]
             SimpleList<Node> InitializeNormal(Node node)
             {
                 var list = new SimpleList<Node>(2 * Log2(tree.Count + 1));
@@ -671,6 +700,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 }
                 return list;
             }
+            [凾(256)]
             SimpleList<Node> InitializeReverse(Node node)
             {
                 var list = new SimpleList<Node>(2 * Log2(tree.Count + 1));
@@ -694,12 +724,13 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 return list;
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             static int Log2(int num) => BitOperations.Log2((uint)num) + 1;
             public Node Current => current;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             internal T CurrentValue() => tree.op.GetValue(current);
 
+            [凾(256)]
             public bool MoveNext()
             {
                 if (stack.Count == 0)
@@ -738,19 +769,20 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             object IEnumerator.Current => Current;
 
             public void Dispose() { }
+            [凾(256)]
             public bool MoveNext() => inner.MoveNext();
             public void Reset() => throw new NotSupportedException();
         }
     }
     public static class SetNodeBaseExt
     {
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool IsNonNullBlack<TNode>(this TNode node) where TNode : SetNodeBase<TNode> => node != null && node.IsBlack;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool IsNonNullRed<TNode>(this TNode node) where TNode : SetNodeBase<TNode> => node != null && node.IsRed;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool IsNullOrBlack<TNode>(this TNode node) where TNode : SetNodeBase<TNode> => node == null || node.IsBlack;
     }
     public class SetNodeBase<TNode> where TNode : SetNodeBase<TNode>
@@ -803,6 +835,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         {
             get; private set;
         } = 1;
+        [凾(256)]
         internal bool UpdateSize()
         {
             var oldsize = this.Size;
@@ -817,12 +850,12 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
         internal bool IsRed => Color == NodeColor.Red;
         internal bool Is2Node => IsBlack && Left.IsNullOrBlack() && Right.IsNullOrBlack();
         internal bool Is4Node => Left.IsNonNullRed() && Right.IsNonNullRed();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal void ColorBlack() => Color = NodeColor.Black;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal void ColorRed() => Color = NodeColor.Red;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TreeRotation GetRotation(TNode current, TNode sibling)
         {
             Debug.Assert(sibling.Left.IsNonNullRed() || sibling.Right.IsNonNullRed());
@@ -832,7 +865,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                 (currentIsLeftChild ? TreeRotation.Left : TreeRotation.LeftRight);
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode GetSibling(TNode node)
         {
             Debug.Assert(node != null);
@@ -840,7 +873,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
 
             return node == Left ? Right : Left;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal void Split4Node()
         {
             Debug.Assert(Left != null);
@@ -850,7 +883,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             Left.ColorBlack();
             Right.ColorBlack();
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode Rotate(TreeRotation rotation)
         {
             TNode removeRed;
@@ -876,7 +909,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
                     throw new InvalidOperationException();
             }
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode RotateLeft()
         {
             TNode child = Right;
@@ -884,7 +917,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             child.Left = this.AsGeneric;
             return child;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode RotateLeftRight()
         {
             TNode child = Left;
@@ -896,7 +929,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             grandChild.Left = child;
             return grandChild;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode RotateRight()
         {
             TNode child = Left;
@@ -904,7 +937,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             child.Right = this.AsGeneric;
             return child;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal TNode RotateRightLeft()
         {
             TNode child = Right;
@@ -916,7 +949,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             grandChild.Right = child;
             return grandChild;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal void Merge2Nodes()
         {
             Debug.Assert(IsRed);
@@ -928,7 +961,7 @@ https://github.com/dotnet/runtime/blob/master/LICENSE.TXT
             Left.ColorRed();
             Right.ColorRed();
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         internal void ReplaceChild(TNode child, TNode newChild)
         {
             if (Left == child)

--- a/Competitive.Library/Collection/Set/SetDictionary.cs
+++ b/Competitive.Library/Collection/Set/SetDictionary.cs
@@ -3,11 +3,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public class SetDictionary<TKey, TValue> : SetDictionary<TKey, TValue, DefaultComparerStruct<TKey>>
         where TKey : IComparable<TKey>
     {
@@ -64,9 +63,9 @@ namespace Kzrnm.Competitive
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => ((IDictionary<TKey, TValue>)this).Values;
         public TValue this[TKey key]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get => FindNode(key).Value;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             set
             {
                 var node = FindNode(key);
@@ -77,9 +76,11 @@ namespace Kzrnm.Competitive
 
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> pair) => Add(pair.Key, pair.Value);
         void IDictionary<TKey, TValue>.Add(TKey key, TValue value) => DoAdd(KeyValuePair.Create(key, value));
+        [凾(256)]
         public bool Add(TKey key, TValue value) => DoAdd(KeyValuePair.Create(key, value));
 
 
+        [凾(256)]
         public bool ContainsKey(TKey key) => FindNode(key) != null;
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> pair)
         {
@@ -93,6 +94,7 @@ namespace Kzrnm.Competitive
             }
             return false;
         }
+        [凾(256)]
         public bool TryGetValue(TKey key, out TValue value)
         {
             var node = FindNode(key);
@@ -124,25 +126,25 @@ namespace Kzrnm.Competitive
             {
                 this.comparer = comparer;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public Node Create(KeyValuePair<TKey, TValue> item, NodeColor color) => new Node(item.Key, item.Value, color);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public KeyValuePair<TKey, TValue> GetValue(Node node) => node.Pair;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void SetValue(ref Node node, KeyValuePair<TKey, TValue> value)
             {
                 node.Key = value.Key;
                 node.Value = value.Value;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public TKey GetCompareKey(KeyValuePair<TKey, TValue> item) => item.Key;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(TKey x, TKey y) => comparer.Compare(x, y);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(KeyValuePair<TKey, TValue> node1, KeyValuePair<TKey, TValue> node2) => comparer.Compare(node1.Key, node2.Key);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(Node node1, Node node2) => comparer.Compare(node1.Key, node2.Key);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(TKey value, Node node) => comparer.Compare(value, node.Key);
         }
         private class DebugView

--- a/Competitive.Library/Collection/Set/SetInterval.cs
+++ b/Competitive.Library/Collection/Set/SetInterval.cs
@@ -6,11 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// 半開区間をSetで保持する
     /// </summary>
@@ -314,25 +313,25 @@ namespace Kzrnm.Competitive
             {
                 this.comparer = comparer;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public Node Create((T From, T ToExclusive) item, NodeColor color) => new Node(item.From, item.ToExclusive, color);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public (T From, T ToExclusive) GetValue(Node node) => node.Pair;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void SetValue(ref Node node, (T From, T ToExclusive) value)
             {
                 node.From = value.From;
                 node.ToExclusive = value.ToExclusive;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T GetCompareKey((T From, T ToExclusive) item) => item.From;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T x, T y) => comparer.Compare(x, y);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare((T From, T ToExclusive) node1, (T From, T ToExclusive) node2) => comparer.Compare(node1.From, node2.From);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(Node node1, Node node2) => comparer.Compare(node1.From, node2.From);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T value, Node node)
             {
                 int forder = comparer.Compare(node.From, value);

--- a/Competitive.Library/Collection/Set/SetIntervalClosed.cs
+++ b/Competitive.Library/Collection/Set/SetIntervalClosed.cs
@@ -6,11 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// 閉区間をSetで保持する
     /// </summary>
@@ -316,25 +315,25 @@ namespace Kzrnm.Competitive
             {
                 this.comparer = comparer;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public Node Create((T From, T ToInclusive) item, NodeColor color) => new Node(item.From, item.ToInclusive, color);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public (T From, T ToInclusive) GetValue(Node node) => node.Pair;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void SetValue(ref Node node, (T From, T ToInclusive) value)
             {
                 node.From = value.From;
                 node.ToInclusive = value.ToInclusive;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T GetCompareKey((T From, T ToInclusive) item) => item.From;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T x, T y) => comparer.Compare(x, y);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare((T From, T ToInclusive) node1, (T From, T ToInclusive) node2) => comparer.Compare(node1.From, node2.From);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(Node node1, Node node2) => comparer.Compare(node1.From, node2.From);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Compare(T value, Node node)
             {
                 int forder = comparer.Compare(node.From, value);

--- a/Competitive.Library/Comparer/ArrayComparer.cs
+++ b/Competitive.Library/Comparer/ArrayComparer.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 
 namespace Kzrnm.Competitive
 {
-    public class BitArrayComparer : IComparer<System.Collections.BitArray>
+    public class ArrayComparer<T> : IComparer<T[]> where T : IComparable<T>
     {
         private readonly bool IsReverse;
-        public BitArrayComparer(bool isReverse = false)
+        public ArrayComparer(bool isReverse = false)
         {
             IsReverse = isReverse;
         }
-        public static readonly BitArrayComparer Default = new BitArrayComparer(false);
-        public static readonly BitArrayComparer Reverse = new BitArrayComparer(true);
-        public int Compare(System.Collections.BitArray x, System.Collections.BitArray y)
+        public static readonly ArrayComparer<T> Default = new ArrayComparer<T>(false);
+        public static readonly ArrayComparer<T> Reverse = new ArrayComparer<T>(true);
+        public int Compare(T[] x, T[] y)
         {
             if (IsReverse)
                 (x, y) = (y, x);

--- a/Competitive.Library/Comparer/BitArrayComparer.cs
+++ b/Competitive.Library/Comparer/BitArrayComparer.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Kzrnm.Competitive
 {
-    public class ArrayComparer<T> : IComparer<T[]> where T : IComparable<T>
+    public class BitArrayComparer : IComparer<System.Collections.BitArray>
     {
         private readonly bool IsReverse;
-        public ArrayComparer(bool isReverse = false)
+        public BitArrayComparer(bool isReverse = false)
         {
             IsReverse = isReverse;
         }
-        public static readonly ArrayComparer<T> Default = new ArrayComparer<T>(false);
-        public static readonly ArrayComparer<T> Reverse = new ArrayComparer<T>(true);
-        public int Compare(T[] x, T[] y)
+        public static readonly BitArrayComparer Default = new BitArrayComparer(false);
+        public static readonly BitArrayComparer Reverse = new BitArrayComparer(true);
+        public int Compare(System.Collections.BitArray x, System.Collections.BitArray y)
         {
             if (IsReverse)
                 (x, y) = (y, x);

--- a/Competitive.Library/Comparer/DefaultComparerStruct.cs
+++ b/Competitive.Library/Comparer/DefaultComparerStruct.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -8,6 +9,7 @@ namespace Kzrnm.Competitive
 #pragma warning restore CA2231 // Overload operator equals on overriding value type Equals
     {
         public static DefaultComparerStruct<T> Default { get; } = default;
+        [凾(256)]
         public int Compare(T x, T y) => x.CompareTo(y);
         public override bool Equals(object obj) => obj is ReverseComparerStruct<T>;
         public override int GetHashCode() => GetType().GetHashCode();

--- a/Competitive.Library/Comparer/ExComparer.cs
+++ b/Competitive.Library/Comparer/ExComparer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -33,6 +34,7 @@ namespace Kzrnm.Competitive
                         paramA, paramB);
                 this.func = compExp.Compile();
             }
+            [凾(256)]
             public int Compare(T x, T y) => func(x, y);
             public override bool Equals(object obj) => obj is ExpressionComparer<K> c && this.func == c.func;
             public override int GetHashCode() => func.GetHashCode();

--- a/Competitive.Library/Comparer/ReverseComparer.cs
+++ b/Competitive.Library/Comparer/ReverseComparer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -10,6 +11,7 @@ namespace Kzrnm.Competitive
         {
             this.orig = orig;
         }
+        [凾(256)]
         public int Compare(T x, T y) => orig.Compare(y, x);
         public override bool Equals(object obj) => obj is ReverseComparer<T>;
         public override int GetHashCode() => GetType().GetHashCode();

--- a/Competitive.Library/Comparer/ReverseComparerClass.cs
+++ b/Competitive.Library/Comparer/ReverseComparerClass.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public class ReverseComparerClass<T> : IComparer<T> where T : IComparable<T>
     {
         public static ReverseComparerClass<T> Default { get; } = new ReverseComparerClass<T>();
+        [凾(256)]
         public int Compare(T x, T y) => y.CompareTo(x);
         public override bool Equals(object obj) => obj is ReverseComparerClass<T>;
         public override int GetHashCode() => GetType().GetHashCode();

--- a/Competitive.Library/Comparer/ReverseComparerStruct.cs
+++ b/Competitive.Library/Comparer/ReverseComparerStruct.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -8,6 +9,7 @@ namespace Kzrnm.Competitive
 #pragma warning restore CA2231 // Overload operator equals on overriding value type Equals
     {
         public static ReverseComparerStruct<T> Default { get; } = default;
+        [凾(256)]
         public int Compare(T x, T y) => y.CompareTo(x);
         public override bool Equals(object obj) => obj is ReverseComparerStruct<T>;
         public override int GetHashCode() => GetType().GetHashCode();

--- a/Competitive.Library/DataStructure/BIT/FenwickTree2D.cs
+++ b/Competitive.Library/DataStructure/BIT/FenwickTree2D.cs
@@ -1,12 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
-
     /// <summary>
     /// 長さ H*W の2次元配列に対し、
     /// <list type="bullet">
@@ -26,7 +23,7 @@ namespace Kzrnm.Competitive
     {
         private static readonly TOp op = default;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public void Add(int h, int w, T v)
         {
             for (var hh = h + 1; hh < tree.Length; hh += (int)InternalBit.ExtractLowestSetBit(hh))
@@ -34,7 +31,7 @@ namespace Kzrnm.Competitive
                     tree[hh][ww] = op.Add(tree[hh][ww], v);
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T Sum(int hExclusive, int wExclusive)
         {
             T res = default;
@@ -53,6 +50,7 @@ namespace Kzrnm.Competitive
         /// 要素の横方向の長さを返します。
         /// </summary>
         public int Width { get; }
+        [凾(256)]
         public Slicer Slice(int from, int length) => new Slicer(this, from, from + length);
 
         public FenwickTree2D(int H, int W)
@@ -76,6 +74,7 @@ namespace Kzrnm.Competitive
                 this.hToExclusive = hToExclusive;
                 this.Length = fw.Width - 1;
             }
+            [凾(256)]
             public T Slice(int wFrom, int length)
             {
                 var wToExclusive = wFrom + length;

--- a/Competitive.Library/DataStructure/BIT/FenwickTreeExtension.cs
+++ b/Competitive.Library/DataStructure/BIT/FenwickTreeExtension.cs
@@ -1,5 +1,6 @@
 ﻿using AtCoder;
 using AtCoder.Operators;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -12,6 +13,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="fw"/> の値が非負。</para>
         /// <para>計算量: O(log <c>n</c>)</para>
         /// </remarks>
+        [凾(256)]
         public static int LowerBound<TValue, TOp>(this FenwickTree<TValue, TOp> fw, TValue v)
             where TOp : struct, IAdditionOperator<TValue>, ISubtractOperator<TValue>, ICompareOperator<TValue>
         {
@@ -37,6 +39,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="fw"/> の値が非負。</para>
         /// <para>計算量: O(log <c>n</c>)</para>
         /// </remarks>
+        [凾(256)]
         public static int UpperBound<TValue, TOp>(this FenwickTree<TValue, TOp> fw, TValue v)
             where TOp : struct, IAdditionOperator<TValue>, ISubtractOperator<TValue>, ICompareOperator<TValue>
         {

--- a/Competitive.Library/DataStructure/BIT/FenwickTreeRange.cs
+++ b/Competitive.Library/DataStructure/BIT/FenwickTreeRange.cs
@@ -1,14 +1,11 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
-
     /// <summary>
     /// 長さ N の配列に対し、
     /// <list type="bullet">
@@ -48,8 +45,7 @@ namespace Kzrnm.Competitive
             data2 = new T[n + 1];
         }
 
-
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private static void Add(T[] data, int p, T w)
         {
             for (++p; p < data.Length; p += (int)InternalBit.ExtractLowestSetBit(p))
@@ -63,7 +59,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="l"/>&lt;n</para>
         /// <para>計算量: O(log n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public void Add(int l, int r, T x)
         {
             Add(data1, l, op.Multiply(op.Minus(x), cast.Cast(l)));
@@ -71,7 +67,7 @@ namespace Kzrnm.Competitive
             Add(data2, l, x);
             Add(data2, r, op.Minus(x));
         }
-
+        [凾(256)]
         private static T Sum(T[] data, int r)
         {
             T res = default;
@@ -87,20 +83,19 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log n)</para>
         /// </remarks>
         /// <returns>a[<paramref name="l"/>] + a[<paramref name="l"/> - 1] + ... + a[<paramref name="r"/> - 1]</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T Sum(int l, int r)
         {
             Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             return op.Subtract(Sum(r), Sum(l));
         }
 
-        [MethodImpl(AggressiveInlining)]
-
+        [凾(256)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Sum(int r) => op.Add(Sum(data1, r), op.Multiply(Sum(data2, r), cast.Cast(r)));
 
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T Slice(int l, int len) => Sum(l, l + len);
 
         [DebuggerDisplay("Value = {" + nameof(value) + "}, Sum = {" + nameof(sum) + "}")]

--- a/Competitive.Library/DataStructure/BinaryTrie.cs
+++ b/Competitive.Library/DataStructure/BinaryTrie.cs
@@ -1,5 +1,6 @@
 ﻿using AtCoder.Internal;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -26,8 +27,10 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="idx"/> に対して −1 以外を与えると accept にそのノードにマッチする全ての値のindexが格納される。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public void Add(ulong num, int delta = 1, int idx = -1, ulong xorVal = 0)
-            => _root = Add(_root, num, idx, MaxDepth, delta, xorVal);
+             => _root = Add(_root, num, idx, MaxDepth, delta, xorVal);
+        [凾(256)]
         Node Add(Node t, ulong bit, int idx, int depth, int x, ulong xorVal)
         {
             if (depth == -1)
@@ -54,15 +57,18 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> をデクリメントする。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public void Remove(ulong num, ulong xorVal = 0)
-            => Add(num, -1, -1, xorVal);
+             => Add(num, -1, -1, xorVal);
 
         /// <summary>
         /// <para><paramref name="num"/> に対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public Node Find(ulong num, ulong xorVal = 0)
-            => Find(_root, num, MaxDepth, xorVal);
+             => Find(_root, num, MaxDepth, xorVal);
+        [凾(256)]
         Node Find(Node t, ulong bit, int depth, ulong xorVal)
         {
             if (depth == -1)
@@ -79,12 +85,14 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> に対応する個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public int Count(ulong num, ulong xorVal = 0) => Find(num, xorVal)?.exist ?? 0;
 
         /// <summary>
         /// <para>最小値と対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) MinElement(ulong xorVal = 0)
         {
             Contract.Assert(_root.exist > 0);
@@ -95,6 +103,7 @@ namespace Kzrnm.Competitive
         /// <para>最大値と対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) MaxElement(ulong xorVal = 0)
         {
             Contract.Assert(_root.exist > 0);
@@ -105,6 +114,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="k"/> 番目(0-indexed) に小さい値とそれに対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) KthElement(int k, ulong xorVal = 0)
         {
             Contract.Assert(0 <= k && k < _root.exist);
@@ -115,6 +125,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> 未満の個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public int CountLess(ulong num, ulong xorVal = 0)
         {
             return CountLess(_root, num, MaxDepth, xorVal);
@@ -126,6 +137,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="k"/> 番目(0-indexed) に小さい値とそれに対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         private (ulong Num, Node Node) KthElement(Node t, int k, int bitIndex, ulong xorVal)
         {
             if (bitIndex == -1)
@@ -146,6 +158,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> 未満の個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         int CountLess(Node t, ulong num, int bitIndex, ulong xorVal)
         {
             if (bitIndex == -1) return 0;

--- a/Competitive.Library/DataStructure/DisjointSparseTable.cs
+++ b/Competitive.Library/DataStructure/DisjointSparseTable.cs
@@ -1,13 +1,11 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using System;
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// <para>結合則が成り立つ半群への区間クエリを, 前計算 O(nlogn), クエリ O(1) で処理する</para>
     /// </summary>
@@ -51,10 +49,10 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Slice(int l, int length) => Prod(l, l + length);
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Prod(int l, int r)
         {
             Contract.Assert((uint)l < (uint)Length, "l < Length");

--- a/Competitive.Library/DataStructure/PersistentBinaryTrie.cs
+++ b/Competitive.Library/DataStructure/PersistentBinaryTrie.cs
@@ -1,5 +1,6 @@
 ﻿using AtCoder.Internal;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -26,8 +27,10 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="idx"/> に対して −1 以外を与えると accept にそのノードにマッチする全ての値のindexが格納される。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public PersistentBinaryTrie Add(ulong num, int delta = 1, int idx = -1, ulong xorVal = 0)
-            => new PersistentBinaryTrie(Add(_root, num, idx, MaxDepth, delta, xorVal), MaxDepth + 1);
+              => new PersistentBinaryTrie(Add(_root, num, idx, MaxDepth, delta, xorVal), MaxDepth + 1);
+        [凾(256)]
         Node Add(Node t, ulong bit, int idx, int depth, int x, ulong xorVal, bool need = true)
         {
             if (need) t = t.Clone();
@@ -56,15 +59,18 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> をデクリメントする。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public PersistentBinaryTrie Remove(ulong num, ulong xorVal = 0)
-            => Add(num, -1, -1, xorVal);
+             => Add(num, -1, -1, xorVal);
 
         /// <summary>
         /// <para><paramref name="num"/> に対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public Node Find(ulong num, ulong xorVal = 0)
-            => Find(_root, num, MaxDepth, xorVal);
+              => Find(_root, num, MaxDepth, xorVal);
+        [凾(256)]
         Node Find(Node t, ulong bit, int depth, ulong xorVal)
         {
             if (depth == -1)
@@ -81,12 +87,14 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> に対応する個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public int Count(ulong num, ulong xorVal = 0) => Find(num, xorVal)?.exist ?? 0;
 
         /// <summary>
         /// <para>最小値と対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) MinElement(ulong xorVal = 0)
         {
             Contract.Assert(_root.exist > 0);
@@ -97,6 +105,7 @@ namespace Kzrnm.Competitive
         /// <para>最大値と対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) MaxElement(ulong xorVal = 0)
         {
             Contract.Assert(_root.exist > 0);
@@ -107,6 +116,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="k"/> 番目(0-indexed) に小さい値とそれに対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public (ulong Num, Node Node) KthElement(int k, ulong xorVal = 0)
         {
             Contract.Assert(0 <= k && k < _root.exist);
@@ -117,6 +127,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> 未満の個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         public int CountLess(ulong num, ulong xorVal = 0)
         {
             return CountLess(_root, num, MaxDepth, xorVal);
@@ -128,6 +139,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="k"/> 番目(0-indexed) に小さい値とそれに対応するノードを返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         private (ulong Num, Node Node) KthElement(Node t, int k, int bitIndex, ulong xorVal)
         {
             if (bitIndex == -1)
@@ -148,6 +160,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="num"/> 未満の個数を返す。</para>
         /// <para>すべての値に <paramref name="xorVal"/> と XOR を取った値で扱う。</para>
         /// </summary>
+        [凾(256)]
         int CountLess(Node t, ulong num, int bitIndex, ulong xorVal)
         {
             if (bitIndex == -1) return 0;

--- a/Competitive.Library/DataStructure/SWAG.cs
+++ b/Competitive.Library/DataStructure/SWAG.cs
@@ -1,8 +1,7 @@
 ﻿using AtCoder;
 using AtCoder.Internal;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -26,6 +25,7 @@ namespace Kzrnm.Competitive
         /// <para>[<paramref name="l"/>..<paramref name="r"/>) の範囲クエリの結果を返す。</para>
         /// <para>計算量: O(N)</para>
         /// </summary>
+        [凾(256)]
         public T Slide(int l, int r)
         {
             Contract.Assert(l <= r, "Range: l <= r");

--- a/Competitive.Library/DataStructure/Segtree/ConvexHullTrick.cs
+++ b/Competitive.Library/DataStructure/Segtree/ConvexHullTrick.cs
@@ -3,12 +3,10 @@ using AtCoder;
 using AtCoder.Internal;
 using AtCoder.Operators;
 using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     [IsOperator]
     public interface IConvexHullTrickOperator<T> { bool UseLeft(T left, T right); }
 
@@ -52,6 +50,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 直線 <paramref name="a"/>x + <paramref name="b"/> を追加します
         /// </summary>
+        [凾(256)]
         public void AddLine(T a, T b) => AddLine(a, b, 1, 0, size);
         /// <summary>
         /// 線分 <paramref name="a"/>x + <paramref name="b"/> (<see cref="xs"/>[l]≦x&lt;<see cref="xs"/>[r]) を追加します
@@ -124,6 +123,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <see cref="xs"/>[<paramref name="i"/>]での最小値・最大値を取得します。
         /// </summary>
+        [凾(256)]
         public T Query(int i) => Query(i, xs[i]);
         private T Query(int k, T x)
         {
@@ -176,14 +176,14 @@ namespace Kzrnm.Competitive
         where TOp : struct, ICompareOperator<T>
     {
         private static TOp op = default;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool UseLeft(T left, T right) => op.LessThan(left, right);
     }
     public struct MaxConvexHullTrickOperator<T, TOp> : IConvexHullTrickOperator<T>
         where TOp : struct, ICompareOperator<T>
     {
         private static TOp op = default;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool UseLeft(T left, T right) => op.GreaterThan(left, right);
     }
 }

--- a/Competitive.Library/DataStructure/Segtree/SLazySegtree.cs
+++ b/Competitive.Library/DataStructure/Segtree/SLazySegtree.cs
@@ -2,7 +2,7 @@
 using AtCoder.Internal;
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -107,19 +107,16 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
+        [凾(256)]
         private void Update(int k) => d[k] = op.Operate(d[2 * k], d[2 * k + 1]);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
+        [凾(256)]
         private void AllApply(int k, F f)
         {
             d[k] = op.Mapping(f, d[k], valSize[k]);
             if (k < size) lz[k] = op.Composition(f, lz[k]);
         }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
+        [凾(256)]
         private void Push(int k)
         {
             AllApply(2 * k, lz[k]);
@@ -137,7 +134,7 @@ namespace Kzrnm.Competitive
         /// <returns></returns>
         public TValue this[int p]
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [凾(256)]
             set
             {
                 Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
@@ -146,7 +143,7 @@ namespace Kzrnm.Competitive
                 d[p] = value;
                 for (int i = 1; i <= log; i++) Update(p >> i);
             }
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [凾(256)]
             get
             {
                 Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
@@ -156,7 +153,7 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public TValue Slice(int l, int len) => Prod(l, l + len);
 
         /// <summary>
@@ -167,7 +164,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log n)</para>
         /// </remarks>
         /// <returns><c>op.Operate</c>(a[<paramref name="l"/>], ..., a[<paramref name="r"/> - 1])</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public TValue Prod(int l, int r)
         {
             Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");

--- a/Competitive.Library/DataStructure/Segtree/Segtree2DCompressed.cs
+++ b/Competitive.Library/DataStructure/Segtree/Segtree2DCompressed.cs
@@ -1,18 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Internal;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-
-namespace Kzrnm.Competitive
+﻿namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// Segtree や  2次元
     /// </summary>
-    public class Segtree2DCompressed
+    internal class Segtree2DCompressed
     {
     }
 }

--- a/Competitive.Library/DataStructure/Segtree/SegtreeBeats.cs
+++ b/Competitive.Library/DataStructure/Segtree/SegtreeBeats.cs
@@ -4,11 +4,10 @@ using AtCoder.Internal;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// モノイドを定義するインターフェイスです。
     /// </summary>
@@ -105,13 +104,13 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(AggressiveInlining)]
 
+        [凾(256)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Update(int k) => d[k] = op.Operate(d[2 * k], d[2 * k + 1]);
 
-        [MethodImpl(AggressiveInlining)]
 
+        [凾(256)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AllApply(int k, F f)
         {
@@ -127,8 +126,8 @@ namespace Kzrnm.Competitive
                 }
             }
         }
-        [MethodImpl(AggressiveInlining)]
 
+        [凾(256)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Push(int k)
         {
@@ -147,7 +146,7 @@ namespace Kzrnm.Competitive
         /// <returns></returns>
         public TValue this[int p]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             set
             {
                 Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
@@ -156,7 +155,7 @@ namespace Kzrnm.Competitive
                 d[p] = value;
                 for (int i = 1; i <= log; i++) Update(p >> i);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get
             {
                 Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
@@ -166,7 +165,7 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Slice(int l, int len) => Prod(l, l + len);
 
         /// <summary>
@@ -177,7 +176,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log n)</para>
         /// </remarks>
         /// <returns><c>Operate</c>(a[<paramref name="l"/>], ..., a[<paramref name="r"/> - 1])</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Prod(int l, int r)
         {
             Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");

--- a/Competitive.Library/DataStructure/Segtree/SegtreeExtension.cs
+++ b/Competitive.Library/DataStructure/Segtree/SegtreeExtension.cs
@@ -1,5 +1,6 @@
 ﻿using AtCoder;
 using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -8,6 +9,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 現在のセグ木の中身を配列にコピーして返します。
         /// </summary>
+        [凾(256)]
         public static TValue[] ToArray<TValue, TOp>(this Segtree<TValue, TOp> seg)
             where TOp : struct, ISegtreeOperator<TValue>
         {

--- a/Competitive.Library/DataStructure/Segtree/StarrySkyTree.cs
+++ b/Competitive.Library/DataStructure/Segtree/StarrySkyTree.cs
@@ -1,11 +1,10 @@
 ﻿using AtCoder;
 using AtCoder.Internal;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive.DataStructure
 {
-    using static MethodImplOptions;
     [System.Diagnostics.DebuggerTypeProxy(typeof(StarrySkyTree<,>.DebugView))]
     public class StarrySkyTree<T, TOp>
         where T : struct
@@ -108,12 +107,12 @@ namespace Kzrnm.Competitive.DataStructure
 
         public long FIdentity => 0;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public long Composition(long f, long g) => f + g;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public long Mapping(long f, long x) => x + f;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public long Operate(long x, long y) => Math.Max(x, y);
     }
 }

--- a/Competitive.Library/DataStructure/Segtree/永続Segtree.cs
+++ b/Competitive.Library/DataStructure/Segtree/永続Segtree.cs
@@ -2,14 +2,13 @@
 using AtCoder.Internal;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 // Original:
 // https://github.com/ei1333/library
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     [DebuggerTypeProxy(typeof(PersistentSegtree<,>.DebugView))]
     public class PersistentSegtree<TValue, TOp> where TOp : struct, ISegtreeOperator<TValue>
     {
@@ -68,20 +67,20 @@ namespace Kzrnm.Competitive
             return Merge(Build(l, (l + r) >> 1, v), Build((l + r) >> 1, r, v));
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private static Node Merge(Node left, Node right) => new Node(op.Operate(left.data, right.data), left, right);
-
 
         /// <summary>
         /// a[<paramref name="p"/>] に <paramref name="v"/> を代入した <see cref="PersistentSegtree{TValue, TOp}"/> を返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public PersistentSegtree<TValue, TOp> SetItem(int p, TValue v)
         {
             Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
             return new PersistentSegtree<TValue, TOp>(Length, Update(p, v, Root, 0, Length));
         }
 
+        [凾(256)]
         private static Node Update(int p, TValue v, Node n, int l, int r)
         {
             if (r <= p || p + 1 <= l)
@@ -103,7 +102,7 @@ namespace Kzrnm.Competitive
         /// <returns></returns>
         public TValue this[int p]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get
             {
                 Contract.Assert((uint)p < (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(p)} && {nameof(p)} < Length");
@@ -111,7 +110,7 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Slice(int l, int len) => Prod(l, l + len);
 
         /// <summary>
@@ -122,14 +121,14 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log n)</para>
         /// </remarks>
         /// <returns><c>Operate</c>(a[<paramref name="l"/>], ..., a[<paramref name="r"/> - 1])</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Prod(int l, int r)
         {
             Contract.Assert(0U <= (uint)l && (uint)l <= (uint)r && (uint)r <= (uint)Length, reason: $"IndexOutOfRange: 0 <= {nameof(l)} && {nameof(l)} <= {nameof(r)} && {nameof(r)} <= Length");
             return Query(l, r, Root, 0, Length);
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private static TValue Query(int a, int b, Node k, int l, int r)
         {
             if (r <= a || b <= l)

--- a/Competitive.Library/DataStructure/SparseTable.cs
+++ b/Competitive.Library/DataStructure/SparseTable.cs
@@ -2,11 +2,10 @@
 using AtCoder.Internal;
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     [IsOperator]
     public interface ISparseTableOperator<T>
     {
@@ -39,10 +38,10 @@ namespace Kzrnm.Competitive
             }
         }
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Slice(int l, int length) => Prod(l, l + length);
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public TValue Prod(int l, int r)
         {
             Contract.Assert((uint)l < (uint)Length, "l < Length");

--- a/Competitive.Library/DataStructure/String/BM.cs
+++ b/Competitive.Library/DataStructure/String/BM.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 #region https://algoful.com/Archive/Algorithm/BMSearch
 #endregion
 
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -12,21 +13,25 @@ namespace Kzrnm.Competitive
         /// BoyerMoore法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static BoyerMoore<T> Create<T>(ReadOnlySpan<T> pattern) => new BoyerMoore<T>(pattern);
         /// <summary>
         /// BoyerMoore法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static BoyerMoore<T> Create<T>(Span<T> pattern) => new BoyerMoore<T>(pattern);
         /// <summary>
         /// BoyerMoore法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static BoyerMoore<T> Create<T>(T[] pattern) => new BoyerMoore<T>(pattern);
         /// <summary>
         /// BoyerMoore法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static BoyerMoore<char> Create(string pattern) => new BoyerMoore<char>(pattern);
     }
     public ref struct BoyerMoore<T>
@@ -38,6 +43,7 @@ namespace Kzrnm.Competitive
             this.pattern = pattern;
             table = CreateTable(pattern);
         }
+        [凾(256)]
         static Dictionary<T, int> CreateTable(ReadOnlySpan<T> pattern)
         {
             var table = new Dictionary<T, int>();
@@ -51,6 +57,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="target"/> の中で pattern と一致するインデックスを1つ返す
         /// </summary>
+        [凾(256)]
         public int Match(ReadOnlySpan<T> target)
         {
             var i = pattern.Length - 1;

--- a/Competitive.Library/DataStructure/String/KMP.cs
+++ b/Competitive.Library/DataStructure/String/KMP.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 #region https://algoful.com/Archive/Algorithm/KMPSearch
 #endregion
 
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -13,21 +14,25 @@ namespace Kzrnm.Competitive
         /// KMP法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static KMP<T> Create<T>(ReadOnlySpan<T> pattern) => new KMP<T>(pattern);
         /// <summary>
         /// KMP法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static KMP<T> Create<T>(Span<T> pattern) => new KMP<T>(pattern);
         /// <summary>
         /// KMP法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static KMP<T> Create<T>(T[] pattern) => new KMP<T>(pattern);
         /// <summary>
         /// KMP法で検索するパターンを初期化する
         /// </summary>
         /// <param name="pattern">検索したいパターン</param>
+        [凾(256)]
         public static KMP<char> Create(string pattern) => new KMP<char>(pattern);
     }
     public readonly ref struct KMP<T>
@@ -35,6 +40,7 @@ namespace Kzrnm.Competitive
         readonly ReadOnlySpan<T> pattern;
         readonly int[] table;
         public KMP(ReadOnlySpan<T> pattern) { this.pattern = pattern; table = CreateTable(pattern); }
+        [凾(256)]
         static int[] CreateTable(ReadOnlySpan<T> pattern)
         {
             var table = new int[pattern.Length + 1];
@@ -51,6 +57,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="target"/> の中で pattern と一致するインデックスを返す
         /// </summary>
+        [凾(256)]
         public Enumerator Matches(ReadOnlySpan<T> target) => new Enumerator(pattern, target, table);
 
         public ref struct Enumerator
@@ -76,6 +83,7 @@ namespace Kzrnm.Competitive
                     list.Add(item);
                 return list;
             }
+            [凾(256)]
             public bool MoveNext()
             {
                 while (index < target.Length)

--- a/Competitive.Library/DataStructure/String/RollingHash.cs
+++ b/Competitive.Library/DataStructure/String/RollingHash.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -31,6 +32,7 @@ namespace Kzrnm.Competitive
 
 
         /** <summary>[<paramref name="from"/>, <paramref name="len"/>) のハッシュ</summary> */
+        [凾(256)]
         public Hash Slice(int from, int len) => new Hash { a = hash1.Slice(from, len), b = hash2.Slice(from, len) };
 
 
@@ -53,6 +55,7 @@ namespace Kzrnm.Competitive
             }
 
             /** <summary>[<paramref name="from"/>, <paramref name="len"/>) のハッシュ</summary> */
+            [凾(256)]
             public ulong Slice(int from, int len) => hash[from + len] - (hash[from] * pow[len]);
         }
 
@@ -82,8 +85,10 @@ namespace Kzrnm.Competitive
                     hash[i + 1] = CalcMod(Mul(hash[i], Base) + s[i]);
             }
 
+            [凾(256)]
             public ulong Slice(int from, int len) => CalcMod(hash[from + len] + POSITIVIZER - Mul(hash[from], powMemo[len]));
 
+            [凾(256)]
             static ulong Mul(ulong l, ulong r)
             {
                 var lu = l >> 31;
@@ -94,6 +99,7 @@ namespace Kzrnm.Competitive
                 return ((lu * ru) << 1) + ld * rd + ((middleBit & MASK30) << 31) + (middleBit >> 30);
             }
 
+            [凾(256)]
             static ulong Mul(ulong l, uint r)
             {
                 var lu = l >> 31;
@@ -102,6 +108,7 @@ namespace Kzrnm.Competitive
                 return (l & MASK31) * rd + ((middleBit & MASK30) << 31) + (middleBit >> 30);
             }
 
+            [凾(256)]
             static ulong CalcMod(ulong val)
             {
                 val = (val & MOD) + (val >> 61);

--- a/Competitive.Library/DataStructure/String/StringLibEx.cs
+++ b/Competitive.Library/DataStructure/String/StringLibEx.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -21,6 +22,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="s"/> と <paramref name="t"/> の LCS(最長共通部分列)を求めます。
         /// </summary>
+        [凾(256)]
         public static T[] LCS<T>(ReadOnlySpan<T> s, ReadOnlySpan<T> t)
         {
             var dp = new int[s.Length + 1][];

--- a/Competitive.Library/DataStructure/String/SuffixArray.cs
+++ b/Competitive.Library/DataStructure/String/SuffixArray.cs
@@ -1,32 +1,34 @@
 ﻿using AtCoder;
 using AtCoder.Internal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public class SuffixArray
     {
+        [凾(256)]
         public static SuffixArray Create(string str)
         {
             var sa = StringLib.SuffixArray(str);
             var lcp = StringLib.LCPArray(str, sa);
             return new SuffixArray(sa, lcp);
         }
+        [凾(256)]
         public static SuffixArray Create<T>(ReadOnlySpan<T> str)
         {
             var sa = StringLib.SuffixArray(str);
             var lcp = StringLib.LCPArray(str, sa);
             return new SuffixArray(sa, lcp);
         }
+        [凾(256)]
         public static SuffixArray Create<T>(Span<T> str)
         {
             var sa = StringLib.SuffixArray(str);
             var lcp = StringLib.LCPArray(str, sa);
             return new SuffixArray(sa, lcp);
         }
+        [凾(256)]
         public static SuffixArray Create<T>(T[] str)
         {
             var sa = StringLib.SuffixArray(str);
@@ -57,6 +59,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// s[<paramref name="i"/>:] と s[<paramref name="j"/>:] の LCP(Longest Common Prefix) の長さ。
         /// </summary>
+        [凾(256)]
         public int LongestCommonPrefix(int i, int j)
         {
             if (i == j) return Length - i;
@@ -86,7 +89,7 @@ namespace Kzrnm.Competitive
         }
         private struct MinOp : ISparseTableOperator<int>
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [凾(256)]
             public int Operate(int x, int y) => Math.Min(x, y);
         }
     }

--- a/Competitive.Library/DataStructure/Trie.cs
+++ b/Competitive.Library/DataStructure/Trie.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -11,7 +12,6 @@ namespace Kzrnm.Competitive
     {
         public Trie() : this(null) { }
         public Trie(IComparer<TKey> comparer) { children = new SortedDictionary<TKey, Trie<TKey, TValue>>(comparer); }
-
 
         readonly SortedDictionary<TKey, Trie<TKey, TValue>> children;
         public bool HasValue { private set; get; }
@@ -26,7 +26,6 @@ namespace Kzrnm.Competitive
             get => _Value;
         }
         public int Count { private set; get; }
-
 
         /// <summary>
         /// <para><paramref name="index"/>から要素を取得する。</para>
@@ -113,15 +112,18 @@ namespace Kzrnm.Competitive
         /// </summary>
         public TValue this[ReadOnlySpan<TKey> key]
         {
+            [凾(256)]
             get
             {
                 var trie = GetChild(key);
-                if (trie != null && trie.HasValue)
-                    return trie.Value;
-                throw new KeyNotFoundException();
+                if (trie?.HasValue != true)
+                    ThrowKeyNotFoundException();
+                return trie.Value;
             }
+            [凾(256)]
             set => Add(key, value);
         }
+        private static void ThrowKeyNotFoundException() => throw new KeyNotFoundException();
 
         public bool Remove(ReadOnlySpan<TKey> key)
         {
@@ -158,6 +160,7 @@ namespace Kzrnm.Competitive
             }
             return true;
         }
+        [凾(256)]
         public bool TryGet(ReadOnlySpan<TKey> key, out TValue value)
         {
             var child = GetChild(key);
@@ -182,7 +185,7 @@ namespace Kzrnm.Competitive
                 list.RemoveLast();
             }
         }
-
+        [凾(256)]
         public IEnumerable<KeyValuePair<TKey[], TValue>> All() => All(new SimpleList<TKey>());
         public void Clear()
         {
@@ -193,6 +196,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="key"/> の prefix となる Trie の値を返します。
         /// </summary>
+        [凾(256)]
         public MatchEnumerator MatchGreedy(ReadOnlySpan<TKey> key)
             => new MatchEnumerator(this, key);
         public ref struct MatchEnumerator
@@ -266,7 +270,9 @@ namespace Kzrnm.Competitive
     {
         public Trie() : base() { }
         public Trie(IComparer<T> comparer) : base(comparer) { }
+        [凾(256)]
         public void Add(ReadOnlySpan<T> key) => Add(key, true);
+        [凾(256)]
         public bool Contains(ReadOnlySpan<T> key) => GetChild(key)?.Value == true;
     }
 }

--- a/Competitive.Library/DataStructure/WaveletMatrix.cs
+++ b/Competitive.Library/DataStructure/WaveletMatrix.cs
@@ -1,15 +1,13 @@
 ﻿// Original: https://ei1333.github.io/library/structure/wavelet/wavelet-matrix.cpp.html
-using AtCoder;
 using AtCoder.Internal;
 using AtCoder.Extension;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     /// <summary>
     /// 2 次元平面上にある点が事前に与えられているとき、オンラインでいろいろなクエリを処理するデータ構造
     /// </summary>
@@ -56,7 +54,7 @@ namespace Kzrnm.Competitive
         /// </summary>
         public T this[int k]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get => ys[mat[k]];
         }
 
@@ -65,6 +63,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
+        [凾(256)]
         public int Rank(T x, int r)
             => pos.TryGetValue(x, out var p) ? mat.Rank(p, r) : 0;
 
@@ -73,7 +72,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T KthSmallest(int l, int r, int k)
             => ys[mat.KthSmallest(l, r, k)];
 
@@ -82,7 +81,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T KthLargest(int l, int r, int k)
             => ys[mat.KthLargest(l, r, k)];
 
@@ -91,7 +90,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int RangeFreq(int l, int r, T lower, T upper)
             => mat.RangeFreq(l, r, ys.LowerBound(lower, comparer), ys.LowerBound(upper, comparer));
 
@@ -100,7 +99,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int RangeFreq(int l, int r, T upper)
             => mat.RangeFreq(l, r, ys.LowerBound(upper, comparer));
 
@@ -110,7 +109,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T? PrevValue(int l, int r, T upper)
         {
             var res = mat.PrevValue(l, r, ys.LowerBound(upper, comparer));
@@ -125,7 +124,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T? NextValue(int l, int r, T lower)
         {
             var res = mat.NextValue(l, r, ys.LowerBound(lower, comparer));
@@ -187,9 +186,9 @@ namespace Kzrnm.Competitive
             }
         }
 
-
+        [凾(256)]
         private (int, int) Succ(bool f, int l, int r, int level)
-             => (matrix[level].Rank(f, l) + (f ? mid[level] : 0), matrix[level].Rank(f, r) + (f ? mid[level] : 0));
+                     => (matrix[level].Rank(f, l) + (f ? mid[level] : 0), matrix[level].Rank(f, r) + (f ? mid[level] : 0));
 
         /// <summary>
         /// <para><paramref name="k"/> 番目の要素を取得する。</para>
@@ -198,6 +197,7 @@ namespace Kzrnm.Competitive
         /// </summary>
         public int this[int k]
         {
+            [凾(256)]
             get
             {
                 int ret = 0;
@@ -216,6 +216,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
+        [凾(256)]
         public int Rank(int x, int r)
         {
             int l = 0;
@@ -231,6 +232,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
+        [凾(256)]
         public int KthSmallest(int l, int r, int k)
         {
             Contract.Assert(0 <= k && k < r - l, reason: $"IndexOutOfRange: 0 <= k && k < r - l");
@@ -254,7 +256,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int KthLargest(int l, int r, int k) => KthSmallest(l, r, r - l - k - 1);
 
         /// <summary>
@@ -262,7 +264,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int RangeFreq(int l, int r, int lower, int upper)
             => RangeFreq(l, r, upper) - RangeFreq(l, r, lower);
 
@@ -271,6 +273,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
+        [凾(256)]
         public int RangeFreq(int l, int r, int upper)
         {
             int res = 0;
@@ -289,7 +292,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int PrevValue(int l, int r, int upper)
         {
             int cnt = RangeFreq(l, r, upper);
@@ -302,7 +305,7 @@ namespace Kzrnm.Competitive
         /// <para>計算量: O(log(V))</para>
         /// <para>  V は最大値。</para>
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int NextValue(int l, int r, int lower)
         {
             int cnt = RangeFreq(l, r, lower);
@@ -319,7 +322,7 @@ namespace Kzrnm.Competitive
                 sum = new uint[block];
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void Set(int k)
             {
                 bit[k >> 5] |= 1U << (k & 0x1F);
@@ -335,14 +338,14 @@ namespace Kzrnm.Competitive
 
             public bool this[int k]
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => ((bit[k >> 5] >> (k & 0x1F)) & 1) != 0;
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Rank(int k) => (int)(sum[k >> 5] + (uint)BitOperations.PopCount(bit[k >> 5] & ((1U << (k & 0x1F)) - 1)));
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Rank(bool val, int k) => val ? Rank(k) : k - Rank(k);
         }
     }

--- a/Competitive.Library/DataStructure/累積和/Sums.cs
+++ b/Competitive.Library/DataStructure/累積和/Sums.cs
@@ -1,6 +1,6 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -26,8 +26,9 @@ namespace Kzrnm.Competitive
             for (var i = 0; i < collection.Count; i++)
                 impl[i + 1] = op.Add(impl[i], collection[i]);
         }
+        [凾(256)]
         public TValue Slice(int from, int length) => op.Subtract(impl[from + length], impl[from]);
-        public TValue this[int toExclusive] => impl[toExclusive];
-        public TValue this[int from, int toExclusive] => op.Subtract(impl[toExclusive], impl[from]);
+        public TValue this[int toExclusive] { [凾(256)] get => impl[toExclusive]; }
+        public TValue this[int from, int toExclusive] { [凾(256)] get => op.Subtract(impl[toExclusive], impl[from]); }
     }
 }

--- a/Competitive.Library/DataStructure/累積和/Sums2D.cs
+++ b/Competitive.Library/DataStructure/累積和/Sums2D.cs
@@ -1,5 +1,5 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -29,6 +29,7 @@ namespace Kzrnm.Competitive
                                 impl[i][j]), arr[i][j]);
             }
         }
+        [凾(256)]
         public Slicer Slice(int left, int length) => new Slicer(impl, left, left + length);
         public readonly ref struct Slicer
         {
@@ -36,6 +37,7 @@ namespace Kzrnm.Competitive
             readonly int left;
             readonly int rightExclusive;
             public int Length { get; }
+            [凾(256)]
             public Slicer(TValue[][] impl, int left, int rightExclusive)
             {
                 this.impl = impl;
@@ -43,6 +45,7 @@ namespace Kzrnm.Competitive
                 this.rightExclusive = rightExclusive;
                 this.Length = impl[0].Length - 1;
             }
+            [凾(256)]
             public TValue Slice(int top, int length)
             {
                 var bottomExclusive = top + length;

--- a/Competitive.Library/Extensions/ArrayExtension.cs
+++ b/Competitive.Library/Extensions/ArrayExtension.cs
@@ -1,42 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class __ArrayExtension
     {
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Fill<T>(this T[] arr, T value)
         {
             arr.AsSpan().Fill(value);
             return arr;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Sort<T>(this T[] arr) { Array.Sort(arr); return arr; }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static string[] Sort(this string[] arr) => Sort(arr, StringComparer.Ordinal);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Sort<T, U>(this T[] arr, Func<T, U> selector) where U : IComparable<U>
         {
             Array.Sort(arr.Select(selector).ToArray(), arr);
             return arr;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Sort<T>(this T[] arr, Comparison<T> comparison) { Array.Sort(arr, comparison); return arr; }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Sort<T>(this T[] arr, IComparer<T> comparer) { Array.Sort(arr, comparer); return arr; }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static T[] Reverse<T>(this T[] arr) { Array.Reverse(arr); return arr; }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T Get<T>(this T[] arr, int index)
         {
             if (index < 0) index += arr.Length;
             return ref arr[index];
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref readonly T GetOrDummy<T>(this ReadOnlySpan<T> arr, int index, T dummy = default)
         {
             if ((uint)index < (uint)arr.Length)
@@ -44,7 +43,7 @@ namespace Kzrnm.Competitive
             Dummy<T>.dummy = dummy;
             return ref Dummy<T>.dummy;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetOrDummy<T>(this Span<T> arr, int index, T dummy = default)
         {
             if ((uint)index < (uint)arr.Length)
@@ -52,7 +51,7 @@ namespace Kzrnm.Competitive
             Dummy<T>.dummy = dummy;
             return ref Dummy<T>.dummy;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetOrDummy<T>(this T[] arr, int index, T dummy = default)
         {
             if ((uint)index < (uint)arr.Length)
@@ -60,7 +59,7 @@ namespace Kzrnm.Competitive
             Dummy<T>.dummy = dummy;
             return ref Dummy<T>.dummy;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetOrDummy<T>(this T[][] arr,
             int index1,
             int index2,
@@ -72,7 +71,7 @@ namespace Kzrnm.Competitive
             Dummy<T>.dummy = dummy;
             return ref Dummy<T>.dummy;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetOrDummy<T>(this T[][][] arr,
             int index1,
             int index2,

--- a/Competitive.Library/Extensions/BitArrayExtension.cs
+++ b/Competitive.Library/Extensions/BitArrayExtension.cs
@@ -2,17 +2,22 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class __BitArrayExtension
     {
+        [凾(256)]
         public static void CopyTo(this BitArray b, int[] array, int index = 0) => b.CopyTo((Array)array, index);
+        [凾(256)]
         public static void CopyTo(this BitArray b, uint[] array, int index = 0) => b.CopyTo((Array)array, index);
+        [凾(256)]
         public static void CopyTo(this BitArray b, bool[] array, int index = 0) => b.CopyTo((Array)array, index);
         /// <summary>
         /// 内部の配列を <see langword="uint"/> の配列にコピーします。
         /// </summary>
+        [凾(256)]
         public static uint[] ToUInt32Array(this BitArray b)
         {
             var arr = new uint[(b.Length + 31) / 32];
@@ -23,6 +28,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// フラグの立っているインデックスを列挙します。
         /// </summary>
+        [凾(256)]
         public static int[] OnBits(this BitArray b)
         {
             var arr = new uint[((b.Length + 63) >> 6) * 2];

--- a/Competitive.Library/Extensions/CollectionExtension.cs
+++ b/Competitive.Library/Extensions/CollectionExtension.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using AtCoder.Internal;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class __CollectionExtension
     {
+        [凾(256)]
         public static TValue Get<TKey, TValue>(this IDictionary<TKey, TValue> dic, TKey key)
         {
             dic.TryGetValue(key, out var v);

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_Chunk.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_Chunk.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -10,6 +11,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// コレクションの要素をいくつかの要素ごとに分割したバッファーにする。最後の要素は数が足りない可能性あり
         /// </summary>
+        [凾(256)]
         public static ChunkBuffer<T> Chunk<T>(this IEnumerable<T> collection, int bufferSize) => new ChunkBuffer<T>(collection, bufferSize);
     }
     namespace LinqInternals
@@ -24,6 +26,7 @@ namespace Kzrnm.Competitive
                 this.bufferSize = bufferSize;
             }
 
+            [凾(256)]
             public IEnumerator<T[]> GetEnumerator()
             {
                 int index = 0;

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_Flatten.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_Flatten.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -9,14 +10,17 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2次元のコレクションを1次元に平滑化
         /// </summary>
+        [凾(256)]
         public static T[] Flatten<T>(this T[][] array) => Flatten((ReadOnlySpan<T[]>)array);
         /// <summary>
         /// 2次元のコレクションを1次元に平滑化
         /// </summary>
+        [凾(256)]
         public static T[] Flatten<T>(this Span<T[]> span) => Flatten((ReadOnlySpan<T[]>)span);
         /// <summary>
         /// 2次元のコレクションを1次元に平滑化
         /// </summary>
+        [凾(256)]
         public static T[] Flatten<T>(this ReadOnlySpan<T[]> span)
         {
             var res = new SimpleList<T>(span.Length * Math.Max(span[0].Length, 1));
@@ -28,6 +32,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2次元のコレクションを1次元に平滑化
         /// </summary>
+        [凾(256)]
         public static T[] Flatten<T>(this IEnumerable<IEnumerable<T>> collection)
         {
             var res = new SimpleList<T>();
@@ -39,6 +44,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2次元のコレクションを1次元に平滑化
         /// </summary>
+        [凾(256)]
         public static char[] Flatten(this string[] strs)
         {
             var res = new SimpleList<char>(strs.Length * Math.Max(strs[0].Length, 1));

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_MaxBy.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_MaxBy.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class __CollectionExtension_MaxBy
     {
+        [凾(256)]
         public static (int index, T max) MaxBy<T>(this T[] arr) where T : IComparable<T>
              => MaxBy((ReadOnlySpan<T>)arr);
+        [凾(256)]
         public static (int index, T max) MaxBy<T>(this Span<T> arr) where T : IComparable<T>
              => MaxBy((ReadOnlySpan<T>)arr);
+        [凾(256)]
         public static (int index, T max) MaxBy<T>(this ReadOnlySpan<T> arr) where T : IComparable<T>
         {
             T max = arr[0];
@@ -23,10 +27,13 @@ namespace Kzrnm.Competitive
             }
             return (maxIndex, max);
         }
+        [凾(256)]
         public static (int index, T max) MaxBy<T, TMax>(this T[] arr, Func<T, TMax> maxBySelector) where TMax : IComparable<TMax>
             => MaxBy((ReadOnlySpan<T>)arr, maxBySelector);
+        [凾(256)]
         public static (int index, T max) MaxBy<T, TMax>(this Span<T> arr, Func<T, TMax> maxBySelector) where TMax : IComparable<TMax>
             => MaxBy((ReadOnlySpan<T>)arr, maxBySelector);
+        [凾(256)]
         public static (int index, T max) MaxBy<T, TMax>(this ReadOnlySpan<T> arr, Func<T, TMax> maxBySelector) where TMax : IComparable<TMax>
         {
             var maxItem = maxBySelector(arr[0]);
@@ -44,6 +51,7 @@ namespace Kzrnm.Competitive
             }
             return (maxIndex, max);
         }
+        [凾(256)]
         public static (TSource item, TMax max) MaxBy<TSource, TMax>
             (this IEnumerable<TSource> source, Func<TSource, TMax> maxBySelector)
             where TMax : IComparable<TMax>

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_MaxMin.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_MaxMin.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -8,6 +9,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最大値と最小値を取得する。空ならデフォルト
         /// </summary>
+        [凾(256)]
         public static (T Min, T Max) MinMax<T>(this IEnumerable<T> collection) where T : IComparable<T>
         {
             using var e = collection.GetEnumerator();
@@ -25,11 +27,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最大値と最小値を取得する。空ならデフォルト
         /// </summary>
+        [凾(256)]
         public static (T Min, T Max) MinMax<T>(this Span<T> collection) where T : IComparable<T>
-            => MinMax((ReadOnlySpan<T>)collection);
+               => MinMax((ReadOnlySpan<T>)collection);
         /// <summary>
         /// 最大値と最小値を取得する。空ならデフォルト
         /// </summary>
+        [凾(256)]
         public static (T Min, T Max) MinMax<T>(this ReadOnlySpan<T> collection) where T : IComparable<T>
         {
             if (collection.IsEmpty) return default((T, T));

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_MinBy.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_MinBy.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class __CollectionExtension_MinBy
     {
+        [凾(256)]
         public static (int index, T min) MinBy<T>(this T[] arr) where T : IComparable<T>
              => MinBy((ReadOnlySpan<T>)arr);
+        [凾(256)]
         public static (int index, T min) MinBy<T>(this Span<T> arr) where T : IComparable<T>
              => MinBy((ReadOnlySpan<T>)arr);
+        [凾(256)]
         public static (int index, T min) MinBy<T>(this ReadOnlySpan<T> arr) where T : IComparable<T>
         {
             T min = arr[0];
@@ -23,10 +27,13 @@ namespace Kzrnm.Competitive
             }
             return (minIndex, min);
         }
+        [凾(256)]
         public static (int index, T min) MinBy<T, TMin>(this T[] arr, Func<T, TMin> minBySelector) where TMin : IComparable<TMin>
             => MinBy((ReadOnlySpan<T>)arr, minBySelector);
+        [凾(256)]
         public static (int index, T min) MinBy<T, TMin>(this Span<T> arr, Func<T, TMin> minBySelector) where TMin : IComparable<TMin>
             => MinBy((ReadOnlySpan<T>)arr, minBySelector);
+        [凾(256)]
         public static (int index, T min) MinBy<T, TMin>(this ReadOnlySpan<T> arr, Func<T, TMin> minBySelector) where TMin : IComparable<TMin>
 
         {
@@ -45,6 +52,7 @@ namespace Kzrnm.Competitive
             }
             return (minIndex, min);
         }
+        [凾(256)]
         public static (TSource item, TMin min) MinBy<TSource, TMin>
             (this IEnumerable<TSource> source, Func<TSource, TMin> minBySelector)
             where TMin : IComparable<TMin>

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_SpanSelect.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_SpanSelect.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class __CollectionExtension_SpanSelect
     {
+        [凾(256)]
         public static TResult[] Select<TSource, TResult>(this Span<TSource> source, Func<TSource, TResult> selector)
             => Select((ReadOnlySpan<TSource>)source, selector);
+        [凾(256)]
         public static TResult[] Select<TSource, TResult>(this ReadOnlySpan<TSource> source, Func<TSource, TResult> selector)
         {
             var res = new TResult[source.Length];
@@ -13,8 +16,10 @@ namespace Kzrnm.Competitive
                 res[i] = selector(source[i]);
             return res;
         }
+        [凾(256)]
         public static TResult[] Select<TSource, TResult>(this Span<TSource> source, Func<TSource, int, TResult> selector)
             => Select((ReadOnlySpan<TSource>)source, selector);
+        [凾(256)]
         public static TResult[] Select<TSource, TResult>(this ReadOnlySpan<TSource> source, Func<TSource, int, TResult> selector)
         {
             var res = new TResult[source.Length];

--- a/Competitive.Library/Extensions/Linq/CollectionExtension_Tupled2.cs
+++ b/Competitive.Library/Extensions/Linq/CollectionExtension_Tupled2.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -7,14 +8,17 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// コレクションの要素2つずつをまとめた配列を返します。
         /// </summary>
+        [凾(256)]
         public static (T, T)[] Tupled2<T>(this T[] collection) => Tupled2((ReadOnlySpan<T>)collection);
         /// <summary>
         /// コレクションの要素2つずつをまとめた配列を返します。
         /// </summary>
+        [凾(256)]
         public static (T, T)[] Tupled2<T>(this Span<T> collection) => Tupled2((ReadOnlySpan<T>)collection);
         /// <summary>
         /// コレクションの要素2つずつをまとめた配列を返します。
         /// </summary>
+        [凾(256)]
         public static (T, T)[] Tupled2<T>(this ReadOnlySpan<T> collection)
         {
             var result = new (T, T)[collection.Length - 1];

--- a/Competitive.Library/Extensions/Linq/MyLinqExtension.cs
+++ b/Competitive.Library/Extensions/Linq/MyLinqExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -9,15 +10,19 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// インデックスをつける
         /// </summary>
+        [凾(256)]
         public static IEnumerable<(TSource Value, int Index)> Indexed<TSource>(this IEnumerable<TSource> source)
-            => source.Select((v, i) => (v, i));
+              => source.Select((v, i) => (v, i));
 
         /// <summary>
         /// 条件に合致するインデックスを返す
         /// </summary>
+        [凾(256)]
         public static IEnumerable<int> WhereBy<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => source.Select((v, i) => (i, v)).Where(t => predicate(t.v)).Select(t => t.i);
+              => source.Select((v, i) => (i, v)).Where(t => predicate(t.v)).Select(t => t.i);
+        [凾(256)]
         public static Dictionary<TKey, int> GroupCount<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) => source.GroupBy(keySelector).ToDictionary(g => g.Key, g => g.Count());
+        [凾(256)]
         public static Dictionary<TKey, int> GroupCount<TKey>(this IEnumerable<TKey> source) => source.GroupCount(i => i);
     }
 }

--- a/Competitive.Library/Extensions/MathExtension.cs
+++ b/Competitive.Library/Extensions/MathExtension.cs
@@ -1,4 +1,5 @@
 ﻿using AtCoder;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -7,7 +8,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="x"/> の <paramref name="y"/> 乗
         /// </summary>
+        [凾(256)]
         public static long Pow(this long x, long y) => MathLibGeneric.Pow<long, LongOperator>(x, y);
-
     }
 }

--- a/Competitive.Library/Extensions/MemoryMarshalExtension.cs
+++ b/Competitive.Library/Extensions/MemoryMarshalExtension.cs
@@ -2,30 +2,30 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class __MemoryMarshalExtension
     {
 #pragma warning disable CS0649
         private class ArrayVal<T> { public T[] arr; }
 #pragma warning restore CS0649
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static Span<T> AsSpan<T>(this List<T> list, int start = 0) => Unsafe.As<ArrayVal<T>>(list).arr.AsSpan(start, list.Count - start);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static Span<TTo> Cast<TFrom, TTo>(this Span<TFrom> span)
             where TFrom : struct
             where TTo : struct
             => MemoryMarshal.Cast<TFrom, TTo>(span);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(this ReadOnlySpan<TFrom> span)
             where TFrom : struct
             where TTo : struct
             => MemoryMarshal.Cast<TFrom, TTo>(span);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetReference<T>(this Span<T> span) => ref MemoryMarshal.GetReference(span);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static ref T GetReference<T>(this ReadOnlySpan<T> span) => ref MemoryMarshal.GetReference(span);
     }
 }

--- a/Competitive.Library/Extensions/UpdateExtension.cs
+++ b/Competitive.Library/Extensions/UpdateExtension.cs
@@ -1,19 +1,18 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class __UpdateExtension
     {
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
 
         public static bool UpdateMax<T>(this ref T r, T val) where T : struct, IComparable<T>
         {
             if (r.CompareTo(val) < 0) { r = val; return true; }
             return false;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static bool UpdateMin<T>(this ref T r, T val) where T : struct, IComparable<T>
         {
             if (r.CompareTo(val) > 0) { r = val; return true; }

--- a/Competitive.Library/Global/BinarySearchEx.cs
+++ b/Competitive.Library/Global/BinarySearchEx.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder;
 using System;
 using System.Numerics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -13,8 +14,9 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static int BinarySearch(int ok, int ng, Func<int, bool> okFunc)
-            => BinarySearch(new FuncOk<int>(okFunc), ok, ng);
+                 => BinarySearch(new FuncOk<int>(okFunc), ok, ng);
         /// <summary>
         /// <paramref name="ok"/> と <paramref name="ng"/> の間で <c>Ok</c>(i) == true を満たす最も <paramref name="ng"/> に近い値を取得します。
         /// </summary>
@@ -22,8 +24,9 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static int BinarySearch<TOp>(int ok, int ng) where TOp : struct, IOk<int>
-            => BinarySearch(default(TOp), ok, ng);
+               => BinarySearch(default(TOp), ok, ng);
         /// <summary>
         /// <paramref name="ok"/> と <paramref name="ng"/> の間で <paramref name="op"/>.Ok(i) == true を満たす最も <paramref name="ng"/> に近い値を取得します。
         /// </summary>
@@ -31,6 +34,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static int BinarySearch<TOp>(this TOp op, int ok, int ng) where TOp : struct, IOk<int>
         {
             while (Math.Abs(ok - ng) > 1)
@@ -49,6 +53,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearch(long ok, long ng, Func<long, bool> okFunc)
             => BinarySearch(new FuncOk<long>(okFunc), ok, ng);
         /// <summary>
@@ -58,6 +63,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearch<TOp>(long ok, long ng) where TOp : struct, IOk<long>
             => BinarySearch(default(TOp), ok, ng);
         /// <summary>
@@ -67,6 +73,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearch<TOp>(this TOp op, long ok, long ng) where TOp : struct, IOk<long>
         {
             while (Math.Abs(ok - ng) > 1)
@@ -85,6 +92,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static ulong BinarySearch(ulong ok, ulong ng, Func<ulong, bool> okFunc)
             => BinarySearch(new FuncOk<ulong>(okFunc), ok, ng);
         /// <summary>
@@ -94,6 +102,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static ulong BinarySearch<TOp>(ulong ok, ulong ng) where TOp : struct, IOk<ulong>
             => BinarySearch(default(TOp), ok, ng);
         /// <summary>
@@ -103,6 +112,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static ulong BinarySearch<TOp>(this TOp op, ulong ok, ulong ng) where TOp : struct, IOk<ulong>
         {
             while ((ok > ng ? ok - ng : ng - ok) > 1)
@@ -121,6 +131,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearch(BigInteger ok, BigInteger ng, Func<BigInteger, bool> okFunc)
             => BinarySearch(new FuncOk<BigInteger>(okFunc), ok, ng);
         /// <summary>
@@ -130,6 +141,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearch<TOp>(BigInteger ok, BigInteger ng) where TOp : struct, IOk<BigInteger>
             => BinarySearch(default(TOp), ok, ng);
         /// <summary>
@@ -139,6 +151,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearch<TOp>(this TOp op, BigInteger ok, BigInteger ng) where TOp : struct, IOk<BigInteger>
         {
             while (BigInteger.Abs(ok - ng) > 1)
@@ -157,6 +170,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearchBig(long ok, Func<long, bool> okFunc)
             => BinarySearchBig(new FuncOk<long>(okFunc), ok);
         /// <summary>
@@ -166,6 +180,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearchBig<TOp>(long ok) where TOp : struct, IOk<long>
             => BinarySearchBig(default(TOp), ok);
         /// <summary>
@@ -175,6 +190,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static long BinarySearchBig<TOp>(this TOp op, long ok) where TOp : struct, IOk<long>
         {
             long plus = 1;
@@ -195,6 +211,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearchBig(BigInteger ok, Func<BigInteger, bool> okFunc)
             => BinarySearchBig(ok, new FuncOk<BigInteger>(okFunc));
         /// <summary>
@@ -204,6 +221,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearchBig<TOp>(BigInteger ok) where TOp : struct, IOk<BigInteger>
             => BinarySearchBig(ok, default(TOp));
         /// <summary>
@@ -213,6 +231,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>)</para>
         /// <para>計算量: O(log |result|)</para>
         /// </remarks>
+        [凾(256)]
         public static BigInteger BinarySearchBig<TOp>(BigInteger ok, TOp op) where TOp : struct, IOk<BigInteger>
         {
             BigInteger plus = 1;
@@ -232,6 +251,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static double BinarySearch(double ok, double ng, Func<double, bool> okFunc, double eps = 1e-7)
             => BinarySearch(new FuncOk<double>(okFunc), ok, ng, eps);
         /// <summary>
@@ -241,6 +261,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <c>Ok</c>(<paramref name="ok"/>) &amp;&amp; !<c>Ok</c>(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static double BinarySearch<TOp>(double ok, double ng, double eps = 1e-7) where TOp : struct, IOk<double>
             => BinarySearch(default(TOp), ok, ng, eps);
         /// <summary>
@@ -250,6 +271,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static double BinarySearch<TOp>(this TOp op, double ok, double ng, double eps = 1e-7) where TOp : struct, IOk<double>
         {
             while (Math.Abs(ok - ng) > eps)
@@ -272,6 +294,7 @@ namespace Kzrnm.Competitive
             {
                 this.ok = ok;
             }
+            [凾(256)]
             public bool Ok(T value) => ok(value);
         }
     }

--- a/Competitive.Library/Global/BinarySearchGenericEx.cs
+++ b/Competitive.Library/Global/BinarySearchGenericEx.cs
@@ -1,6 +1,6 @@
 ﻿using AtCoder;
 using System;
-using System.Numerics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -13,8 +13,9 @@ namespace Kzrnm.Competitive
         /// <para>制約: <typeparamref name="TOp"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<typeparamref name="TOp"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static T BinarySearch<T, TOp>(T ok, T ng) where TOp : struct, IBinaryOk<T>
-            => BinarySearch(default(TOp), ok, ng);
+               => BinarySearch(default(TOp), ok, ng);
         /// <summary>
         /// <paramref name="ok"/> と <paramref name="ng"/> の間で <paramref name="op"/>.Ok(i) == true を満たす最も <paramref name="ng"/> に近い値を取得します。
         /// </summary>
@@ -22,6 +23,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: <paramref name="op"/>.Ok(<paramref name="ok"/>) &amp;&amp; !<paramref name="op"/>.Ok(<paramref name="ng"/>)</para>
         /// <para>計算量: O(log |<paramref name="ok"/> - <paramref name="ng"/>|)</para>
         /// </remarks>
+        [凾(256)]
         public static T BinarySearch<T, TOp>(TOp op, T ok, T ng) where TOp : struct, IBinaryOk<T>
         {
             while (op.Continue(ok, ng))
@@ -43,8 +45,11 @@ namespace Kzrnm.Competitive
                 this.mid = mid;
                 this.continueFunc = continueFunc;
             }
+            [凾(256)]
             public bool Ok(T value) => ok(value);
+            [凾(256)]
             public T Mid(T ok, T ng) => mid(ok, ng);
+            [凾(256)]
             public bool Continue(T ok, T ng) => continueFunc(ok, ng);
         }
     }

--- a/Competitive.Library/Global/BitOperationsEx.cs
+++ b/Competitive.Library/Global/BitOperationsEx.cs
@@ -1,84 +1,83 @@
 ﻿using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class BitOperationsEx
     {
         /// <summary>
         /// <paramref name="x"/> の立っているビットの数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int PopCount(uint x) => BitOperations.PopCount(x);
         /// <summary>
         /// <paramref name="x"/> の立っているビットの数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int PopCount(ulong x) => BitOperations.PopCount(x);
         /// <summary>
         /// <paramref name="x"/> の立っているビットの数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int PopCount(int x) => BitOperations.PopCount((uint)x);
         /// <summary>
         /// <paramref name="x"/> の立っているビットの数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int PopCount(long x) => BitOperations.PopCount((ulong)x);
         /// <summary>
         /// <paramref name="x"/> の最上位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int MSB(uint x) => BitOperations.Log2(x);
         /// <summary>
         /// <paramref name="x"/> の最上位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int MSB(ulong x) => BitOperations.Log2(x);
         /// <summary>
         /// <paramref name="x"/> の最上位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int MSB(int x) => BitOperations.Log2((uint)x);
         /// <summary>
         /// <paramref name="x"/> の最上位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int MSB(long x) => BitOperations.Log2((ulong)x);
         /// <summary>
         /// <paramref name="x"/> の最下位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int LSB(uint x) => BitOperations.TrailingZeroCount(x);
         /// <summary>
         /// <paramref name="x"/> の最下位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int LSB(ulong x) => BitOperations.TrailingZeroCount(x);
         /// <summary>
         /// <paramref name="x"/> の最下位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int LSB(int x) => BitOperations.TrailingZeroCount((uint)x);
         /// <summary>
         /// <paramref name="x"/> の最下位ビット
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int LSB(long x) => BitOperations.TrailingZeroCount((ulong)x);
 
         /// <summary>
         /// <para><paramref name="x"/> を <paramref name="mask"/> に移す</para>
         /// </summary>
         /// <returns>ex. x=0b1101 mask=0b11110000 → 0b11010000</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int ParallelBitDeposit(int x, uint mask) => (int)ParallelBitDeposit((uint)x, mask);
         /// <summary>
         /// <para><paramref name="x"/> を <paramref name="mask"/> に移す</para>
         /// </summary>
         /// <returns>ex. x=0b1101 mask=0b11110000 → 0b11010000</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static uint ParallelBitDeposit(uint x, uint mask)
         {
             if (Bmi2.IsSupported)
@@ -103,13 +102,13 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="x"/> の <paramref name="mask"/> に合致する箇所を取り出す</para>
         /// </summary>
         /// <returns>ex. x=0b01101 mask=0b11110 → 0b110</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int ParallelBitExtract(int x, uint mask) => (int)ParallelBitExtract((uint)x, mask);
         /// <summary>
         /// <para><paramref name="x"/> の <paramref name="mask"/> に合致する箇所を取り出す</para>
         /// </summary>
         /// <returns>ex. x=0b101101 mask=0b011110 → 0b110</returns>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static uint ParallelBitExtract(uint x, uint mask)
         {
             if (Bmi2.IsSupported)

--- a/Competitive.Library/Global/Global.cs
+++ b/Competitive.Library/Global/Global.cs
@@ -1,47 +1,56 @@
 ﻿using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class Global
     {
         #region NewArray
+        [凾(256)]
         public static T[] NewArray<T>(int len0, T value) where T : struct => new T[len0].Fill(value);
+        [凾(256)]
         public static T[] NewArray<T>(int len0, Func<T> factory)
         {
             var arr = new T[len0];
             for (int i = 0; i < arr.Length; i++) arr[i] = factory();
             return arr;
         }
+        [凾(256)]
         public static T[][] NewArray<T>(int len0, int len1, T value) where T : struct
         {
             var arr = new T[len0][];
             for (int i = 0; i < arr.Length; i++) arr[i] = NewArray(len1, value);
             return arr;
         }
+        [凾(256)]
         public static T[][] NewArray<T>(int len0, int len1, Func<T> factory)
         {
             var arr = new T[len0][];
             for (int i = 0; i < arr.Length; i++) arr[i] = NewArray(len1, factory);
             return arr;
         }
+        [凾(256)]
         public static T[][][] NewArray<T>(int len0, int len1, int len2, T value) where T : struct
         {
             var arr = new T[len0][][];
             for (int i = 0; i < arr.Length; i++) arr[i] = NewArray(len1, len2, value);
             return arr;
         }
+        [凾(256)]
         public static T[][][] NewArray<T>(int len0, int len1, int len2, Func<T> factory)
         {
             var arr = new T[len0][][];
             for (int i = 0; i < arr.Length; i++) arr[i] = NewArray(len1, len2, factory);
             return arr;
         }
+        [凾(256)]
         public static T[][][][] NewArray<T>(int len0, int len1, int len2, int len3, T value) where T : struct
         {
             var arr = new T[len0][][][];
             for (int i = 0; i < arr.Length; i++) arr[i] = NewArray(len1, len2, len3, value);
             return arr;
         }
+        [凾(256)]
         public static T[][][][] NewArray<T>(int len0, int len1, int len2, int len3, Func<T> factory)
         {
             var arr = new T[len0][][][];

--- a/Competitive.Library/Graph/Data/LinkCutTree.cs
+++ b/Competitive.Library/Graph/Data/LinkCutTree.cs
@@ -1,9 +1,8 @@
 ﻿// https://ei1333.github.io/luzhiled/snippets/structure/link-cut-tree.html
 using AtCoder;
 using AtCoder.Internal;
-using System;
 using System.Collections.Generic;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -48,21 +47,25 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// ID が <paramref name="idx"/>, 値に <paramref name="val"/> を入れたノードを新しく生成する。
         /// </summary>
+        [凾(256)]
         public Node MakeNode(int idx, T val) => new Node(idx, val);
 
 
+        [凾(256)]
         private void Propagate(Node t, F x)
         {
             t.lazy = op.Composition(x, t.lazy);
             t.Key = op.Mapping(x, t.Key, 1);
             t.Sum = op.Mapping(x, t.Sum, t.size);
         }
+        [凾(256)]
         private void Toggle(Node t)
         {
             (t.Right, t.Left) = (t.Left, t.Right);
             t.Sum = op.Inverse(t.Sum);
             t.rev = !t.rev;
         }
+        [凾(256)]
         private void Push(Node t)
         {
             if (t.Left != null) Propagate(t.Left, t.lazy);
@@ -77,6 +80,7 @@ namespace Kzrnm.Competitive
             }
         }
 
+        [凾(256)]
         private void Update(Node t)
         {
             t.size = 1;
@@ -93,6 +97,7 @@ namespace Kzrnm.Competitive
             }
         }
 
+        [凾(256)]
         private void RotationRight(Node t)
         {
             var x = t.Parent;
@@ -113,6 +118,7 @@ namespace Kzrnm.Competitive
             }
         }
 
+        [凾(256)]
         private void RotationLeft(Node t)
         {
             var x = t.Parent;
@@ -131,6 +137,7 @@ namespace Kzrnm.Competitive
                 Update(y);
             }
         }
+        [凾(256)]
         private void Splay(Node t)
         {
             Push(t);
@@ -168,6 +175,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="t"/> と根との間を Heavy-edge でつなげる。戻り値は t ではないので注意。
         /// </summary>
+        [凾(256)]
         public Node Expose(Node t)
         {
             Node rp = null;
@@ -186,6 +194,7 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="child"/> の親を <paramref name="parent"/> にする。</para>
         /// <para>制約: <paramref name="child"/> と <paramref name="parent"/>が非連結。</para>
         /// </summary>
+        [凾(256)]
         public void Link(Node child, Node parent)
         {
             Contract.Assert(Lca(child, parent) == null);
@@ -200,6 +209,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="child"/> の親と <paramref name="child"/> を切り離す。
         /// </summary>
+        [凾(256)]
         public void Cut(Node child)
         {
             Expose(child);
@@ -212,6 +222,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="t"/> を木の根にする。
         /// </summary>
+        [凾(256)]
         public void Evert(Node t)
         {
             Expose(t);
@@ -222,6 +233,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="u"/> と <paramref name="v"/> の最小共通祖先を返す。
         /// </summary>
+        [凾(256)]
         public Node Lca(Node u, Node v)
         {
             if (GetRoot(u) != GetRoot(v)) return null;
@@ -232,6 +244,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="x"/> から根までのパスに出現する頂点を返す(O(n))。
         /// </summary>
+        [凾(256)]
         public int[] GetPath(Node x)
         {
             var vs = new SList<int>();
@@ -260,6 +273,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 根からノード <paramref name="t"/> までのパスに作用素 <paramref name="x"/> を適用する。
         /// </summary>
+        [凾(256)]
         public void SetPropagate(Node t, F x)
         {
             Expose(t);
@@ -273,6 +287,7 @@ namespace Kzrnm.Competitive
         /// <param name="x"></param>
         /// <param name="k"></param>
         /// <returns></returns>
+        [凾(256)]
         public Node GetKth(Node x, int k)
         {
             Expose(x);
@@ -297,6 +312,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="x"/> の根を返す。
         /// </summary>
+        [凾(256)]
         public Node GetRoot(Node x)
         {
             Expose(x);
@@ -314,6 +330,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// ID が <paramref name="idx"/> のノードを新しく生成する。
         /// </summary>
+        [凾(256)]
         public Node MakeNode(int idx) => new Node(idx, null);
     }
     public struct NullOperator : ILinkCutTreeOperator<object, object>

--- a/Competitive.Library/Graph/Data/PathDoubling.WithData.cs
+++ b/Competitive.Library/Graph/Data/PathDoubling.WithData.cs
@@ -1,6 +1,6 @@
 ﻿using AtCoder;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -71,7 +71,7 @@ namespace Kzrnm.Competitive
         /// </summary>
         /// <param name="start">: スタートするインデックス</param>
         /// <param name="moveNum">: 移動回数</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public (int To, T Data) Move(int start, long moveNum) => Move(start, (ulong)moveNum);
         /// <summary>
         /// <para><paramref name="start"/>: スタートするインデックス</para>
@@ -79,7 +79,7 @@ namespace Kzrnm.Competitive
         /// </summary>
         /// <param name="start">: スタートするインデックス</param>
         /// <param name="moveNum">: 移動回数</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public (int To, T Data) Move(int start, ulong moveNum)
         {
             T d = op.Identity;

--- a/Competitive.Library/Graph/Data/PathDoubling.cs
+++ b/Competitive.Library/Graph/Data/PathDoubling.cs
@@ -1,5 +1,5 @@
 ﻿using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -56,7 +56,7 @@ namespace Kzrnm.Competitive
         /// <param name="start">: スタートするインデックス</param>
         /// <param name="moveNum">: 移動回数</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public int Move(int start, long moveNum) => Move(start, (ulong)moveNum);
         /// <summary>
         /// <para><paramref name="start"/>: スタートするインデックス</para>
@@ -65,7 +65,7 @@ namespace Kzrnm.Competitive
         /// <param name="start">: スタートするインデックス</param>
         /// <param name="moveNum">: 移動回数</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public int Move(int start, ulong moveNum)
         {
             int current = start;

--- a/Competitive.Library/Graph/Data/PathLoop.cs
+++ b/Competitive.Library/Graph/Data/PathLoop.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -48,14 +46,14 @@ namespace Kzrnm.Competitive
         /// </summary>
         /// <param name="moveNum">: 移動回数</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public int Move(long moveNum) => Move((ulong)moveNum);
         /// <summary>
         /// <para><paramref name="moveNum"/>: 移動回数</para>
         /// </summary>
         /// <param name="moveNum">: 移動回数</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public int Move(ulong moveNum)
         {
             if (moveNum < (ulong)Straight.Length)
@@ -69,7 +67,7 @@ namespace Kzrnm.Competitive
         /// </summary>
         /// <param name="moveNum">: 移動回数</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public int Move(BigInteger moveNum)
         {
             if (moveNum < Straight.Length)

--- a/Competitive.Library/Graph/EdgeContainer.cs
+++ b/Competitive.Library/Graph/EdgeContainer.cs
@@ -1,4 +1,5 @@
 ﻿using AtCoder.Internal;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -17,6 +18,7 @@ namespace Kzrnm.Competitive
             rootSizes = isDirected ? new int[size] : sizes;
             edges = new SimpleList<(int from, TEdge edge)>(size);
         }
+        [凾(256)]
         public void Add(int from, TEdge edge)
         {
             ++sizes[from];
@@ -24,6 +26,7 @@ namespace Kzrnm.Competitive
             edges.Add((from, edge));
         }
 
+        [凾(256)]
         public CSR<TEdge> ToCSR() => new CSR<TEdge>(Length, edges);
     }
 }

--- a/Competitive.Library/Graph/Graph.cs
+++ b/Competitive.Library/Graph/Graph.cs
@@ -1,5 +1,6 @@
 ﻿using AtCoder.Internal;
 using System.Diagnostics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -28,8 +29,9 @@ namespace Kzrnm.Competitive
         public CSR<TEdge> Edges { get; }
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         internal TNode[] Nodes { get; }
+        [凾(256)]
         public TNode[] AsArray() => Nodes;
-        public TNode this[int index] => Nodes[index];
+        public TNode this[int index] { [凾(256)] get => Nodes[index]; }
         public int Length => Nodes.Length;
         public SimpleGraph(TNode[] array, CSR<TEdge> edges)
         {
@@ -43,8 +45,9 @@ namespace Kzrnm.Competitive
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         internal TNode[] Nodes { get; }
+        [凾(256)]
         public TNode[] AsArray() => Nodes;
-        public TNode this[int index] => Nodes[index];
+        public TNode this[int index] { [凾(256)] get => Nodes[index]; }
         public int Length => Nodes.Length;
         public int Root { get; }
         public TreeGraph(TNode[] array, int root)

--- a/Competitive.Library/Graph/GraphBuilder.cs
+++ b/Competitive.Library/Graph/GraphBuilder.cs
@@ -4,6 +4,7 @@ using AtCoder.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -35,6 +36,7 @@ namespace Kzrnm.Competitive
                 gb.Add(cr.Int0, cr.Int0);
             return gb;
         }
+        [凾(256)]
         public void Add(int from, int to) => edgeContainer.Add(from, new GraphEdge(to));
 
 
@@ -127,8 +129,10 @@ namespace Kzrnm.Competitive
             To = to;
         }
         public int To { get; }
+        [凾(256)]
         public static implicit operator int(GraphEdge e) => e.To;
         public override string ToString() => To.ToString();
+        [凾(256)]
         public GraphEdge Reversed(int from) => new GraphEdge(from);
 
         public override int GetHashCode() => this.To;

--- a/Competitive.Library/Graph/GraphBuilderGeneric.cs
+++ b/Competitive.Library/Graph/GraphBuilderGeneric.cs
@@ -1,9 +1,9 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using Kzrnm.Competitive.IO;
 using AtCoder.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -14,6 +14,7 @@ namespace Kzrnm.Competitive
         {
             edgeContainer = new EdgeContainer<GraphEdge<T>>(size, isDirected);
         }
+        [凾(256)]
         public void Add(int from, int to, T data) => edgeContainer.Add(from, new GraphEdge<T>(to, data));
 
 
@@ -110,11 +111,13 @@ namespace Kzrnm.Competitive
         public T Data { get; }
         public int To { get; }
         public override string ToString() => $"to:{To}, Data:{Data}";
+        [凾(256)]
         public void Deconstruct(out int to, out T data)
         {
             to = To;
             data = Data;
         }
+        [凾(256)]
         public GraphEdge<T> Reversed(int from) => new GraphEdge<T>(from, Data);
 
         public override int GetHashCode() => this.To;

--- a/Competitive.Library/Graph/GraphNode.cs
+++ b/Competitive.Library/Graph/GraphNode.cs
@@ -1,9 +1,5 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using Kzrnm.Competitive.IO;
-using AtCoder.Internal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Kzrnm.Competitive
 {

--- a/Competitive.Library/Graph/GraphToWeighted.cs
+++ b/Competitive.Library/Graph/GraphToWeighted.cs
@@ -1,7 +1,4 @@
 ﻿using AtCoder;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Kzrnm.Competitive
 {

--- a/Competitive.Library/Graph/IGraphNode.cs
+++ b/Competitive.Library/Graph/IGraphNode.cs
@@ -1,5 +1,4 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using System;
 
 namespace Kzrnm.Competitive
 {

--- a/Competitive.Library/Graph/UnionFind/DynamicConnectivity.cs
+++ b/Competitive.Library/Graph/UnionFind/DynamicConnectivity.cs
@@ -3,12 +3,11 @@
 using AtCoder.Internal;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
 
     /// <summary>
     /// <para>削除可能 UnionFind を O(log^2 N) で操作できるデータ構造です。</para>
@@ -24,46 +23,46 @@ namespace Kzrnm.Competitive
             internal byte flag;
             public bool Exact
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0001;
                     else flag &= unchecked((byte)~0b0001);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0001) > 0;
             }
             public bool ChildExact
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0010;
                     else flag &= unchecked((byte)~0b0010);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0010) > 0;
             }
             public bool EdgeConnected
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0100;
                     else flag &= unchecked((byte)~0b0100);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0100) > 0;
             }
             public bool ChildEdgeConnected
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b1000;
                     else flag &= unchecked((byte)~0b1000);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b1000) > 0;
             }
             public Node(int l, int r)
@@ -85,7 +84,7 @@ namespace Kzrnm.Competitive
 #else
             private Dictionary<int, Node>[] ptr;
 #endif
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private Node GetNode(int l, int r)
             {
 #if DynamicConnectivity_TUPLEDIC
@@ -106,20 +105,20 @@ namespace Kzrnm.Competitive
                 return t;
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             bool Same(Node s, Node t)
             {
                 if (s != null) Splay(s);
                 if (t != null) Splay(t);
                 return Root(s) == Root(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             Node ReRoot(Node t)
             {
                 var (s1, s2) = Split(t);
                 return Merge(s2, s1);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node) Split(Node s)
             {
                 Splay(s);
@@ -128,7 +127,7 @@ namespace Kzrnm.Competitive
                 s.ch0 = null;
                 return (t, Update(s));
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node) Split2(Node s)
             {
                 Splay(s);
@@ -140,7 +139,7 @@ namespace Kzrnm.Competitive
                 s.ch1 = null;
                 return (t, u);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node, Node) Split(Node s, Node t)
             {
                 var (u1, u2) = Split2(s);
@@ -162,9 +161,9 @@ namespace Kzrnm.Competitive
                 return Update(s);
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private int Size(Node t) => t != null ? t.size : 0;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private Node Update(Node t)
             {
                 t.size = Size(t.ch0) + Size(t.ch1) + (t.l == t.r ? 1 : 0);
@@ -259,19 +258,19 @@ namespace Kzrnm.Competitive
 #endif
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Size(int s)
             {
                 Node t = GetNode(s, s);
                 Splay(t);
                 return t.size;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Same(int s, int t)
             {
                 return Same(GetNode(s, s), GetNode(t, t));
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void UpdateEdge(int s, UpdateEdgeStatus st)
             {
                 void Dfs(Node t, UpdateEdgeStatus st)
@@ -301,7 +300,7 @@ namespace Kzrnm.Competitive
                     Splay(t);
                 }
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool TryReconnect(int s, ReconnectStatus r)
             {
                 bool Dfs(Node t, ReconnectStatus r)
@@ -328,7 +327,7 @@ namespace Kzrnm.Competitive
                 }
                 return false;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void UpdateEdgeConnected(int s, bool b)
             {
                 Node t = GetNode(s, s);
@@ -336,7 +335,7 @@ namespace Kzrnm.Competitive
                 t.EdgeConnected = b;
                 Update(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Link(int l, int r)
             {
                 if (Same(l, r)) return false;
@@ -346,7 +345,7 @@ namespace Kzrnm.Competitive
                         Merge(ReRoot(GetNode(r, r)), GetNode(r, l))));
                 return true;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Cut(int l, int r)
             {
 #if DynamicConnectivity_TUPLEDIC
@@ -384,7 +383,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log^2 n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Link(int s, int t)
         {
             if (s == t) return false;
@@ -408,12 +407,12 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Same(int s, int t) => ett[0].Same(s, t);
         /// <summary>
         /// <paramref name="s"/> と連結している頂点の数を返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Size(int s) => ett[0].Size(s);
 
         //private int[] GetVertex(int s)
@@ -428,7 +427,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log^2 n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Cut(int s, int t)
         {
             if (s == t) return false;

--- a/Competitive.Library/Graph/UnionFind/DynamicConnectivity`2.cs
+++ b/Competitive.Library/Graph/UnionFind/DynamicConnectivity`2.cs
@@ -3,12 +3,11 @@ using AtCoder;
 using AtCoder.Internal;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
 
     /// <summary>
     /// <para>削除可能 UnionFind</para>
@@ -34,46 +33,46 @@ namespace Kzrnm.Competitive
             internal byte flag;
             public bool Exact
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0001;
                     else flag &= unchecked((byte)~0b0001);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0001) > 0;
             }
             public bool ChildExact
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0010;
                     else flag &= unchecked((byte)~0b0010);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0010) > 0;
             }
             public bool EdgeConnected
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b0100;
                     else flag &= unchecked((byte)~0b0100);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b0100) > 0;
             }
             public bool ChildEdgeConnected
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 set
                 {
                     if (value) flag |= 0b1000;
                     else flag &= unchecked((byte)~0b1000);
                 }
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get => (flag & 0b1000) > 0;
             }
             public Node(int l, int r)
@@ -91,7 +90,7 @@ namespace Kzrnm.Competitive
         class EulerianTourTree
         {
             private Dictionary<(int, int), Node> ptr;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private Node GetNode(int l, int r)
             {
                 if (ptr.TryGetValue((l, r), out var node))
@@ -105,20 +104,20 @@ namespace Kzrnm.Competitive
                 return t;
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             bool Same(Node s, Node t)
             {
                 if (s != null) Splay(s);
                 if (t != null) Splay(t);
                 return Root(s) == Root(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             Node ReRoot(Node t)
             {
                 var (s1, s2) = Split(t);
                 return Merge(s2, s1);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node) Split(Node s)
             {
                 Splay(s);
@@ -127,7 +126,7 @@ namespace Kzrnm.Competitive
                 s.ch0 = null;
                 return (t, Update(s));
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node) Split2(Node s)
             {
                 Splay(s);
@@ -139,7 +138,7 @@ namespace Kzrnm.Competitive
                 s.ch1 = null;
                 return (t, u);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             (Node, Node, Node) Split(Node s, Node t)
             {
                 var (u1, u2) = Split2(s);
@@ -161,9 +160,9 @@ namespace Kzrnm.Competitive
                 return Update(s);
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private int Size(Node t) => t != null ? t.size : 0;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             private Node Update(Node t)
             {
                 t.prod = op.Identity;
@@ -256,19 +255,19 @@ namespace Kzrnm.Competitive
                     ptr[(i, i)] = new Node(i, i);
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public int Size(int s)
             {
                 Node t = GetNode(s, s);
                 Splay(t);
                 return t.size;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Same(int s, int t)
             {
                 return Same(GetNode(s, s), GetNode(t, t));
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void SetValue(int s, T x)
             {
                 Node t = GetNode(s, s);
@@ -276,7 +275,7 @@ namespace Kzrnm.Competitive
                 t.val = x;
                 Update(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void Apply(int s, T x)
             {
                 Node t = GetNode(s, s);
@@ -284,7 +283,7 @@ namespace Kzrnm.Competitive
                 t.val = op.Operate(t.val, x);
                 Update(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void UpdateEdge(int s, UpdateEdgeStatus st)
             {
                 void Dfs(Node t, UpdateEdgeStatus st)
@@ -314,7 +313,7 @@ namespace Kzrnm.Competitive
                     Splay(t);
                 }
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool TryReconnect(int s, ReconnectStatus r)
             {
                 bool Dfs(Node t, ReconnectStatus r)
@@ -341,7 +340,7 @@ namespace Kzrnm.Competitive
                 }
                 return false;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public void UpdateEdgeConnected(int s, bool b)
             {
                 Node t = GetNode(s, s);
@@ -349,7 +348,7 @@ namespace Kzrnm.Competitive
                 t.EdgeConnected = b;
                 Update(t);
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Link(int l, int r)
             {
                 if (Same(l, r)) return false;
@@ -359,7 +358,7 @@ namespace Kzrnm.Competitive
                         Merge(ReRoot(GetNode(r, r)), GetNode(r, l))));
                 return true;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool Cut(int l, int r)
             {
                 if (!ptr.ContainsKey((l, r))) return false;
@@ -369,7 +368,7 @@ namespace Kzrnm.Competitive
                 ptr.Remove((r, l));
                 return true;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T Prod(int p, int v)
             {
                 Cut(p, v);
@@ -379,14 +378,14 @@ namespace Kzrnm.Competitive
                 Link(p, v);
                 return res;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T Prod(int s)
             {
                 Node t = GetNode(s, s);
                 Splay(t);
                 return t.prod;
             }
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public T GetValue(int s)
             {
                 Node t = GetNode(s, s);
@@ -415,7 +414,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log^2 n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Link(int s, int t)
         {
             if (s == t) return false;
@@ -439,12 +438,12 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Same(int s, int t) => ett[0].Same(s, t);
         /// <summary>
         /// <paramref name="s"/> と連結している頂点の数を返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Size(int s) => ett[0].Size(s);
 
         //private int[] GetVertex(int s)
@@ -459,7 +458,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="s"/>, <paramref name="t"/>&lt;n</para>
         /// <para>計算量: O(log^2 n)</para>
         /// </remarks>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool Cut(int s, int t)
         {
             if (s == t) return false;
@@ -574,22 +573,22 @@ namespace Kzrnm.Competitive
         /// </summary>
         public T this[int s]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get => ett[0].GetValue(s);
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             set => ett[0].SetValue(s, value);
         }
 
         /// <summary>
         /// <paramref name="s"/> 番目の値 v を <c>Operate(v, <paramref name="x"/>)</c> で更新します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public void Apply(int s, T x) => ett[0].Apply(s, x);
 
         /// <summary>
         /// <paramref name="s"/> と連結している頂点の総積を返します。
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public T Prod(int s) => ett[0].Prod(s);
     }
 }

--- a/Competitive.Library/Graph/UnionFind/PartiallyPersistentUnionFind.cs
+++ b/Competitive.Library/Graph/UnionFind/PartiallyPersistentUnionFind.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using AtCoder.Internal;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -45,6 +45,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: O(log(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Merge(int a, int b)
         {
             ++Version;
@@ -73,6 +74,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: O(log(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Same(int a, int b, int t)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -87,6 +89,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: O(log(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Leader(int a, int t)
         {
             if (t < _updatedVersion[a])
@@ -102,6 +105,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: O(log(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Size(int a, int t)
         {
             Contract.Assert(0 <= a && a < _n);

--- a/Competitive.Library/Graph/UnionFind/PersistentUnionFind.cs
+++ b/Competitive.Library/Graph/UnionFind/PersistentUnionFind.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using AtCoder.Internal;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -37,6 +36,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: O(log^2(n))</para>
         /// </remarks>
+        [凾(256)]
         public PersistentUnionFind Merge(int a, int b)
         {
             Contract.Assert(0 <= a && a < _parentOrSize.Count);
@@ -62,6 +62,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: O(log^2(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Same(int a, int b)
         {
             Contract.Assert(0 <= a && a < _parentOrSize.Count);
@@ -76,6 +77,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: O(log^2(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Leader(int a)
         {
             var p = _parentOrSize[a];
@@ -91,6 +93,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: O(log^2(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Size(int a)
         {
             Contract.Assert(0 <= a && a < _parentOrSize.Count);

--- a/Competitive.Library/Graph/UnionFind/UnionFind.cs
+++ b/Competitive.Library/Graph/UnionFind/UnionFind.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
 using System.Diagnostics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -32,6 +33,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Merge(int a, int b)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -51,6 +53,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Same(int a, int b)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -65,6 +68,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Leader(int a)
         {
             if (_parentOrSize[a] < 0) return a;
@@ -83,6 +87,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Size(int a)
         {
             Contract.Assert(0 <= a && a < _n);

--- a/Competitive.Library/Graph/UnionFind/UnionFind`1.cs
+++ b/Competitive.Library/Graph/UnionFind/UnionFind`1.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
 using System.Diagnostics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -38,6 +39,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Merge(int a, int b)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -58,6 +60,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Same(int a, int b)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -72,6 +75,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Leader(int a)
         {
             if (_parentOrSize[a] < 0) return a;
@@ -90,6 +94,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Size(int a)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -103,6 +108,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public T Data(int a)
         {
             Contract.Assert(0 <= a && a < _n);

--- a/Competitive.Library/Graph/UnionFind/WeightedUnionFind.cs
+++ b/Competitive.Library/Graph/UnionFind/WeightedUnionFind.cs
@@ -2,6 +2,7 @@
 using AtCoder.Internal;
 using AtCoder.Operators;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -39,6 +40,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Merge(int a, int b, T w)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -66,6 +68,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public bool Same(int a, int b)
         {
             Contract.Assert(0 <= a && a < _n);
@@ -80,6 +83,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Leader(int a)
         {
             if (_parentOrSize[a] < 0) return a;
@@ -95,6 +99,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         T Weight(int a)
         {
             Leader(a);
@@ -108,6 +113,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>, <paramref name="b"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public T WeightDiff(int a, int b) => op.Subtract(Weight(b), Weight(a));
 
         /// <summary>
@@ -117,6 +123,7 @@ namespace Kzrnm.Competitive
         /// <para>制約: 0≤<paramref name="a"/>&lt;n</para>
         /// <para>計算量: ならしO(a(n))</para>
         /// </remarks>
+        [凾(256)]
         public int Size(int a)
         {
             Contract.Assert(0 <= a && a < _n);

--- a/Competitive.Library/Graph/Utils/オイラーツアー.cs
+++ b/Competitive.Library/Graph/Utils/オイラーツアー.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -17,7 +16,9 @@ namespace Kzrnm.Competitive
                 this.edge = edge;
                 this.isStart = isStart;
             }
+            [凾(256)]
             public Event Reverse() => new Event(root, edge, !isStart);
+            [凾(256)]
             public (int From, int To) Route() => isStart ? (root, edge.To) : (edge.To, root);
             public override string ToString() => $"{root}{(isStart ? '→' : '←')}{edge}";
         }
@@ -118,7 +119,7 @@ namespace Kzrnm.Competitive
         }
         private struct NodeMinOp : ISparseTableOperator<(int Node, int Depth)>
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [凾(256)]
             public (int Node, int Depth) Operate((int Node, int Depth) x, (int Node, int Depth) y) => x.Depth <= y.Depth ? x : y;
         }
     }

--- a/Competitive.Library/Graph/Utils/強連結成分分解.cs
+++ b/Competitive.Library/Graph/Utils/強連結成分分解.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using AtCoder.Internal;
 
 namespace Kzrnm.Competitive
 {

--- a/Competitive.Library/Graph/Utils/最小全域木Prim.cs
+++ b/Competitive.Library/Graph/Utils/最小全域木Prim.cs
@@ -1,5 +1,4 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
 using System.Collections.Generic;
 

--- a/Competitive.Library/Graph/Utils/最小共通祖先.WithData.cs
+++ b/Competitive.Library/Graph/Utils/最小共通祖先.WithData.cs
@@ -1,6 +1,6 @@
 ﻿using AtCoder;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -36,13 +36,14 @@ namespace Kzrnm.Competitive
         /// </summary>
         public (int Index, T Data) this[int u, int v]
         {
-            [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+            [凾(256)]
             get => Lca(u, v);
         }
 
         /// <summary>
         /// 2つの頂点の共通祖先とその経路のデータをマージした値を取得する
         /// </summary>
+        [凾(256)]
         public (int Index, T Data) Lca(int u, int v)
         {
             var op = doubling.op;
@@ -74,6 +75,7 @@ namespace Kzrnm.Competitive
         /// <para>2つの頂点の共通祖先のそれぞれの子(最小非共通祖先)を返します。</para>
         /// <para>一方がもう一方の祖先の場合は祖先の方は自身を返します。</para>
         /// </summary>
+        [凾(256)]
         public (int uAncestor, int vAncestor) ChildOfLca(int u, int v)
         {
             int dd = tree[u].Depth - tree[v].Depth;
@@ -110,6 +112,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2つの頂点の距離を取得する
         /// </summary>
+        [凾(256)]
         public int Distance(int u, int v)
         {
             var lca = Lca(u, v).Index;

--- a/Competitive.Library/Graph/Utils/最小共通祖先.cs
+++ b/Competitive.Library/Graph/Utils/最小共通祖先.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -32,13 +32,14 @@ namespace Kzrnm.Competitive
         /// </summary>
         public int this[int u, int v]
         {
-            [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+            [凾(256)]
             get => Lca(u, v);
         }
 
         /// <summary>
         /// 2つの頂点の共通祖先を取得する
         /// </summary>
+        [凾(256)]
         public int Lca(int u, int v)
         {
             int dd = tree[u].Depth - tree[v].Depth;
@@ -64,6 +65,7 @@ namespace Kzrnm.Competitive
         /// <para>2つの頂点の共通祖先のそれぞれの子(最小非共通祖先)を返します。</para>
         /// <para>一方がもう一方の祖先の場合は祖先の方は自身を返します。</para>
         /// </summary>
+        [凾(256)]
         public (int uAncestor, int vAncestor) ChildOfLca(int u, int v)
         {
             int dd = tree[u].Depth - tree[v].Depth;
@@ -100,6 +102,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2つの頂点の距離を取得する
         /// </summary>
+        [凾(256)]
         public int Distance(int u, int v)
         {
             var lca = this[u, v];

--- a/Competitive.Library/Graph/Utils/最短経路WarshallFloyd.cs
+++ b/Competitive.Library/Graph/Utils/最短経路WarshallFloyd.cs
@@ -1,4 +1,5 @@
 ﻿using AtCoder.Operators;
+
 namespace Kzrnm.Competitive
 {
     public static class 最短経路WarshallFloyd

--- a/Competitive.Library/Graph/Utils/木の子孫数.cs
+++ b/Competitive.Library/Graph/Utils/木の子孫数.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -7,9 +8,10 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 自身を含む子孫ノードの数を返す
         /// </summary>
+        [凾(256)]
         public static int[] DescendantsCounts<TNode, TEdge>(this ITreeGraph<TNode, TEdge> tree)
-            where TNode : ITreeNode<TEdge>
-            where TEdge : IGraphEdge
+              where TNode : ITreeNode<TEdge>
+              where TEdge : IGraphEdge
         {
             var treeArr = tree.AsArray();
             var res = new int[treeArr.Length];

--- a/Competitive.Library/Graph/Utils/木の探索.cs
+++ b/Competitive.Library/Graph/Utils/木の探索.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -7,9 +8,10 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 木を幅優先探索するときに訪れる順序に並んだインデックスを返す
         /// </summary>
+        [凾(256)]
         public static int[] BfsDescendant<TNode, TEdge>(this ITreeGraph<TNode, TEdge> tree, bool skipFirst = false)
-            where TNode : ITreeNode<TEdge>
-            where TEdge : IGraphEdge
+              where TNode : ITreeNode<TEdge>
+              where TEdge : IGraphEdge
         {
             var arr = tree.AsArray();
             var res = new int[arr.Length - (skipFirst ? 1 : 0)];
@@ -34,9 +36,10 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 木を深さ優先探索するときに訪れる順序に並んだインデックスを返す
         /// </summary>
+        [凾(256)]
         public static int[] DfsDescendant<TNode, TEdge>(this ITreeGraph<TNode, TEdge> tree, bool skipFirst = false)
-            where TNode : ITreeNode<TEdge>
-            where TEdge : IGraphEdge
+               where TNode : ITreeNode<TEdge>
+               where TEdge : IGraphEdge
         {
             var arr = tree.AsArray();
             var res = new int[arr.Length - (skipFirst ? 1 : 0)];

--- a/Competitive.Library/Graph/Utils/閉路検出DFS.cs
+++ b/Competitive.Library/Graph/Utils/閉路検出DFS.cs
@@ -1,7 +1,7 @@
 ﻿
 using AtCoder.Internal;
-using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -11,9 +11,10 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 閉路があれば返す。なければ(-1, null)
         /// </summary>
+        [凾(256)]
         public static (int from, TEdge[] edges) GetCycleDFS<TNode, TEdge>(this IGraph<TNode, TEdge> graph)
-            where TNode : IGraphNode<TEdge>
-            where TEdge : IGraphEdge
+             where TNode : IGraphNode<TEdge>
+             where TEdge : IGraphEdge
         {
             var statuses = new Status[graph.Length];
             (int from, SimpleList<TEdge> edges) DFS(Stack<(int v, int childIdx)> stack)

--- a/Competitive.Library/Graph/WGraph.cs
+++ b/Competitive.Library/Graph/WGraph.cs
@@ -1,7 +1,7 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
 using System.Diagnostics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -23,8 +23,9 @@ namespace Kzrnm.Competitive
         public CSR<TEdge> Edges { get; }
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         internal TNode[] Nodes { get; }
+        [凾(256)]
         public TNode[] AsArray() => Nodes;
-        public TNode this[int index] => Nodes[index];
+        public TNode this[int index] { [凾(256)] get => Nodes[index]; }
         public int Length => Nodes.Length;
         public WGraph(TNode[] array, CSR<TEdge> edges)
         {
@@ -39,8 +40,9 @@ namespace Kzrnm.Competitive
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         internal TNode[] Nodes { get; }
+        [凾(256)]
         public TNode[] AsArray() => Nodes;
-        public TNode this[int index] => Nodes[index];
+        public TNode this[int index] { [凾(256)] get => Nodes[index]; }
         public int Length => Nodes.Length;
         public int Root { get; }
         public WTreeGraph(TNode[] array, int root)

--- a/Competitive.Library/Graph/WGraphBuilder.cs
+++ b/Competitive.Library/Graph/WGraphBuilder.cs
@@ -1,10 +1,10 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using AtCoder;
 using AtCoder.Internal;
 using AtCoder.Operators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -17,6 +17,7 @@ namespace Kzrnm.Competitive
         {
             edgeContainer = new EdgeContainer<WEdge<T>>(size, isDirected);
         }
+        [凾(256)]
         public void Add(int from, int to, T value) => edgeContainer.Add(from, new WEdge<T>(to, value));
 
         public WGraph<T, TOp, WGraphNode<T, WEdge<T>>, WEdge<T>> ToGraph()
@@ -118,11 +119,13 @@ namespace Kzrnm.Competitive
         public static bool operator ==(WEdge<T> left, WEdge<T> right) => left.Equals(right);
         public static bool operator !=(WEdge<T> left, WEdge<T> right) => !(left == right);
         public override string ToString() => (To, Value).ToString();
+        [凾(256)]
         public void Deconstruct(out int to, out T value)
         {
             to = To;
             value = Value;
         }
+        [凾(256)]
         public WEdge<T> Reversed(int from) => new WEdge<T>(from, Value);
     }
 }

--- a/Competitive.Library/Graph/WGraphBuilderGeneric.cs
+++ b/Competitive.Library/Graph/WGraphBuilderGeneric.cs
@@ -1,10 +1,10 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using AtCoder;
 using AtCoder.Internal;
 using AtCoder.Operators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -17,6 +17,7 @@ namespace Kzrnm.Competitive
         {
             edgeContainer = new EdgeContainer<WEdge<T, S>>(size, isDirected);
         }
+        [凾(256)]
         public void Add(int from, int to, T value, S data) => edgeContainer.Add(from, new WEdge<T, S>(to, value, data));
 
         public WGraph<T, TOp, WGraphNode<T, WEdge<T, S>>, WEdge<T, S>> ToGraph()
@@ -122,12 +123,14 @@ namespace Kzrnm.Competitive
         public static bool operator ==(WEdge<T, S> left, WEdge<T, S> right) => left.Equals(right);
         public static bool operator !=(WEdge<T, S> left, WEdge<T, S> right) => !(left == right);
         public override string ToString() => $"to:{To}, Value:{Value}, Data:{Data}";
+        [凾(256)]
         public void Deconstruct(out int to, out T value, out S data)
         {
             to = To;
             value = Value;
             data = Data;
         }
+        [凾(256)]
         public WEdge<T, S> Reversed(int from) => new WEdge<T, S>(from, Value, Data);
     }
 }

--- a/Competitive.Library/Graph/WGraphNode.cs
+++ b/Competitive.Library/Graph/WGraphNode.cs
@@ -1,9 +1,5 @@
 ﻿#pragma warning disable CA1819 // Properties should not return arrays
-using Kzrnm.Competitive.IO;
-using AtCoder.Internal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Kzrnm.Competitive
 {

--- a/Competitive.Library/Graph/Wrappers/WIntGraphBuilder.cs
+++ b/Competitive.Library/Graph/Wrappers/WIntGraphBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using AtCoder;
-using AtCoder.Operators;
 using Kzrnm.Competitive.IO;
 
 namespace Kzrnm.Competitive

--- a/Competitive.Library/Graph/Wrappers/WLongGraphBuilder.cs
+++ b/Competitive.Library/Graph/Wrappers/WLongGraphBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using AtCoder;
-using AtCoder.Operators;
 using Kzrnm.Competitive.IO;
 
 namespace Kzrnm.Competitive

--- a/Competitive.Library/Graph/Wrappers/WULongGraphBuilder.cs
+++ b/Competitive.Library/Graph/Wrappers/WULongGraphBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using AtCoder;
-using AtCoder.Operators;
 using Kzrnm.Competitive.IO;
 
 namespace Kzrnm.Competitive

--- a/Competitive.Library/Math/BigFraction.cs
+++ b/Competitive.Library/Math/BigFraction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -50,36 +51,53 @@ namespace Kzrnm.Competitive
         }
         public override string ToString() => $"{Numerator}/{Denominator}";
         public override bool Equals(object obj) => obj is BigFraction f && Equals(f);
+        [凾(256)]
         public bool Equals(BigFraction other) => this._numerator == other._numerator && this._denominator == other._denominator;
         public override int GetHashCode() => HashCode.Combine(_numerator, _denominator);
 
+        [凾(256)]
         public static implicit operator BigFraction(long x) => new BigFraction(x, 1);
+        [凾(256)]
         public static implicit operator BigFraction(BigInteger x) => new BigFraction(x, 1);
+        [凾(256)]
         public int CompareTo(BigFraction other) => (this.Numerator * other.Denominator).CompareTo(other.Numerator * this.Denominator);
 
+        [凾(256)]
         public static BigFraction operator -(BigFraction x) => new BigFraction(-x.Numerator, x.Denominator);
+        [凾(256)]
         public static BigFraction operator +(BigFraction x, BigFraction y)
         {
             var gcd = BigInteger.GreatestCommonDivisor(x.Denominator, y.Denominator);
             var lcm = x.Denominator / gcd * y.Denominator;
             return new BigFraction((x.Numerator * y.Denominator + y.Numerator * x.Denominator) / gcd, lcm);
         }
+        [凾(256)]
         public static BigFraction operator -(BigFraction x, BigFraction y)
         {
             var gcd = BigInteger.GreatestCommonDivisor(x.Denominator, y.Denominator);
             var lcm = x.Denominator / gcd * y.Denominator;
             return new BigFraction((x.Numerator * y.Denominator - y.Numerator * x.Denominator) / gcd, lcm);
         }
+        [凾(256)]
         public static BigFraction operator *(BigFraction x, BigFraction y) => new BigFraction(x.Numerator * y.Numerator, x.Denominator * y.Denominator);
+        [凾(256)]
         public static BigFraction operator /(BigFraction x, BigFraction y) => new BigFraction(x.Numerator * y.Denominator, x.Denominator * y.Numerator);
+        [凾(256)]
         public static bool operator ==(BigFraction x, BigFraction y) => x.Equals(y);
+        [凾(256)]
         public static bool operator !=(BigFraction x, BigFraction y) => !x.Equals(y);
+        [凾(256)]
         public static bool operator >=(BigFraction x, BigFraction y) => x.CompareTo(y) >= 0;
+        [凾(256)]
         public static bool operator <=(BigFraction x, BigFraction y) => x.CompareTo(y) <= 0;
+        [凾(256)]
         public static bool operator >(BigFraction x, BigFraction y) => x.CompareTo(y) > 0;
+        [凾(256)]
         public static bool operator <(BigFraction x, BigFraction y) => x.CompareTo(y) < 0;
 
+        [凾(256)]
         public BigFraction Inverse() => new BigFraction(Denominator, Numerator);
+        [凾(256)]
         public double ToDouble() => (double)Numerator / (double)Denominator;
     }
 }

--- a/Competitive.Library/Math/BigFractionOperator.cs
+++ b/Competitive.Library/Math/BigFractionOperator.cs
@@ -1,44 +1,43 @@
 ﻿using AtCoder.Operators;
 using System;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public struct BigFractionOperator : INumOperator<BigFraction>, ICompareOperator<BigFraction>
     {
         public BigFraction MinValue => BigInteger.MinusOne << 10000;
         public BigFraction MaxValue => BigInteger.One << 10000;
         public BigFraction MultiplyIdentity => new BigFraction(1, 1);
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Add(BigFraction x, BigFraction y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Subtract(BigFraction x, BigFraction y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Multiply(BigFraction x, BigFraction y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Divide(BigFraction x, BigFraction y) => x / y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Modulo(BigFraction x, BigFraction y) => throw new NotSupportedException();
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Compare(BigFraction x, BigFraction y) => x.CompareTo(y);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThan(BigFraction x, BigFraction y) => x > y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThanOrEqual(BigFraction x, BigFraction y) => x >= y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThan(BigFraction x, BigFraction y) => x < y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThanOrEqual(BigFraction x, BigFraction y) => x <= y;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Minus(BigFraction x) => -x;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Increment(BigFraction x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigFraction Decrement(BigFraction x) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/BigIntegerEx.cs
+++ b/Competitive.Library/Math/BigIntegerEx.cs
@@ -1,12 +1,10 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
 #pragma warning disable IDE0057
     public static class BigIntegerEx
     {
@@ -35,6 +33,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="y"/> 乗した値を返します。
         /// </summary>
+        [凾(256)]
         public static BigInteger Pow(this BigInteger x, long y) => MathLibGeneric.Pow<BigInteger, BigIntegerOperator>(x, y);
     }
 
@@ -44,35 +43,35 @@ namespace Kzrnm.Competitive
         public BigInteger MaxValue => -BigInteger.One << 10000;
         public BigInteger MultiplyIdentity => BigInteger.One;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Add(BigInteger x, BigInteger y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Subtract(BigInteger x, BigInteger y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Multiply(BigInteger x, BigInteger y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Divide(BigInteger x, BigInteger y) => x / y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Modulo(BigInteger x, BigInteger y) => x % y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Minus(BigInteger x) => -x;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Increment(BigInteger x) => ++x;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger Decrement(BigInteger x) => --x;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThan(BigInteger x, BigInteger y) => x > y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThanOrEqual(BigInteger x, BigInteger y) => x >= y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThan(BigInteger x, BigInteger y) => x < y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThanOrEqual(BigInteger x, BigInteger y) => x <= y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Compare(BigInteger x, BigInteger y) => x.CompareTo(y);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger LeftShift(BigInteger x, int y) => x << y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public BigInteger RightShift(BigInteger x, int y) => x >> y;
     }
 }

--- a/Competitive.Library/Math/ConvolutionAnyMod.cs
+++ b/Competitive.Library/Math/ConvolutionAnyMod.cs
@@ -2,10 +2,8 @@
 using AtCoder.Internal;
 using System;
 using System.Diagnostics;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -20,8 +18,9 @@ namespace Kzrnm.Competitive
         /// <para>- |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^24 = 16,777,216</para>
         /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|))</para>
         /// </remarks>
+        [凾(256)]
         public static uint[] Convolution(ReadOnlySpan<int> a, ReadOnlySpan<int> b, int mod)
-            => Convolution(MemoryMarshal.Cast<int, uint>(a), MemoryMarshal.Cast<int, uint>(b), mod);
+             => Convolution(MemoryMarshal.Cast<int, uint>(a), MemoryMarshal.Cast<int, uint>(b), mod);
 
         /// <summary>
         /// 任意 Mod で畳み込みを計算します。
@@ -32,6 +31,7 @@ namespace Kzrnm.Competitive
         /// <para>- |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^24 = 16,777,216</para>
         /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|))</para>
         /// </remarks>
+        [凾(256)]
         public static uint[] Convolution(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b, int mod)
         {
             uint umod = (uint)mod;
@@ -94,9 +94,10 @@ namespace Kzrnm.Competitive
         /// <para>- |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^24 = 16,777,216</para>
         /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|))</para>
         /// </remarks>
+        [凾(256)]
         public static uint[] Convolution<TMod>(ReadOnlySpan<int> a, ReadOnlySpan<int> b)
-            where TMod : struct, IStaticMod
-            => Convolution<TMod>(MemoryMarshal.Cast<int, uint>(a), MemoryMarshal.Cast<int, uint>(b));
+              where TMod : struct, IStaticMod
+              => Convolution<TMod>(MemoryMarshal.Cast<int, uint>(a), MemoryMarshal.Cast<int, uint>(b));
 
         /// <summary>
         /// 任意 Mod で畳み込みを計算します。
@@ -107,8 +108,9 @@ namespace Kzrnm.Competitive
         /// <para>- |<paramref name="a"/>| + |<paramref name="b"/>| - 1 ≤ 2^24 = 16,777,216</para>
         /// <para>計算量: O((|<paramref name="a"/>|+|<paramref name="b"/>|)log(|<paramref name="a"/>|+|<paramref name="b"/>|))</para>
         /// </remarks>
+        [凾(256)]
         public static uint[] Convolution<TMod>(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b)
-            where TMod : struct, IStaticMod
+             where TMod : struct, IStaticMod
         {
             var mod = default(TMod).Mod;
             if (default(TMod).IsPrime && a.Length + b.Length - 1 <= (1 << InternalBit.BSF(mod - 1)))

--- a/Competitive.Library/Math/Fraction.cs
+++ b/Competitive.Library/Math/Fraction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -49,35 +50,51 @@ namespace Kzrnm.Competitive
         }
         public override string ToString() => $"{Numerator}/{Denominator}";
         public override bool Equals(object obj) => obj is Fraction f && Equals(f);
+        [凾(256)]
         public bool Equals(Fraction other) => this._numerator == other._numerator && this._denominator == other._denominator;
         public override int GetHashCode() => HashCode.Combine(_numerator, _denominator);
 
+        [凾(256)]
         public static implicit operator Fraction(long x) => new Fraction(x, 1);
+        [凾(256)]
         public int CompareTo(Fraction other) => (this.Numerator * other.Denominator).CompareTo(other.Numerator * this.Denominator);
 
+        [凾(256)]
         public static Fraction operator -(Fraction x) => new Fraction(-x.Numerator, x.Denominator);
+        [凾(256)]
         public static Fraction operator +(Fraction x, Fraction y)
         {
             var gcd = MathLibEx.Gcd(x.Denominator, y.Denominator);
             var lcm = x.Denominator / gcd * y.Denominator;
             return new Fraction((x.Numerator * y.Denominator + y.Numerator * x.Denominator) / gcd, lcm);
         }
+        [凾(256)]
         public static Fraction operator -(Fraction x, Fraction y)
         {
             var gcd = MathLibEx.Gcd(x.Denominator, y.Denominator);
             var lcm = x.Denominator / gcd * y.Denominator;
             return new Fraction((x.Numerator * y.Denominator - y.Numerator * x.Denominator) / gcd, lcm);
         }
+        [凾(256)]
         public static Fraction operator *(Fraction x, Fraction y) => new Fraction(x.Numerator * y.Numerator, x.Denominator * y.Denominator);
+        [凾(256)]
         public static Fraction operator /(Fraction x, Fraction y) => new Fraction(x.Numerator * y.Denominator, x.Denominator * y.Numerator);
+        [凾(256)]
         public static bool operator ==(Fraction x, Fraction y) => x.Equals(y);
+        [凾(256)]
         public static bool operator !=(Fraction x, Fraction y) => !x.Equals(y);
+        [凾(256)]
         public static bool operator >=(Fraction x, Fraction y) => x.CompareTo(y) >= 0;
+        [凾(256)]
         public static bool operator <=(Fraction x, Fraction y) => x.CompareTo(y) <= 0;
+        [凾(256)]
         public static bool operator >(Fraction x, Fraction y) => x.CompareTo(y) > 0;
+        [凾(256)]
         public static bool operator <(Fraction x, Fraction y) => x.CompareTo(y) < 0;
 
+        [凾(256)]
         public Fraction Inverse() => new Fraction(Denominator, Numerator);
+        [凾(256)]
         public double ToDouble() => (double)Numerator / Denominator;
     }
 }

--- a/Competitive.Library/Math/FractionOperator.cs
+++ b/Competitive.Library/Math/FractionOperator.cs
@@ -1,43 +1,42 @@
 ﻿using AtCoder.Operators;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public struct FractionOperator : INumOperator<Fraction>, ICompareOperator<Fraction>
     {
         public Fraction MinValue => new Fraction(long.MinValue, 1);
         public Fraction MaxValue => new Fraction(long.MaxValue, 1);
         public Fraction MultiplyIdentity => new Fraction(1, 1);
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Add(Fraction x, Fraction y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Subtract(Fraction x, Fraction y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Multiply(Fraction x, Fraction y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Divide(Fraction x, Fraction y) => x / y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Modulo(Fraction x, Fraction y) => throw new NotSupportedException();
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Compare(Fraction x, Fraction y) => x.CompareTo(y);
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThan(Fraction x, Fraction y) => x > y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool GreaterThanOrEqual(Fraction x, Fraction y) => x >= y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThan(Fraction x, Fraction y) => x < y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public bool LessThanOrEqual(Fraction x, Fraction y) => x <= y;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Minus(Fraction x) => -x;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Increment(Fraction x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Fraction Decrement(Fraction x) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/Kitamasa.Inner.cs
+++ b/Competitive.Library/Math/Kitamasa.Inner.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder;
 using AtCoder.Internal;
 using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -43,6 +44,7 @@ namespace Kzrnm.Competitive
                 }
             }
 
+            [凾(256)]
             public uint[] MultiplyMod(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b)
             {
                 var beta = Convolution(a, b);
@@ -54,9 +56,11 @@ namespace Kzrnm.Competitive
                 return result;
             }
 
+            [凾(256)]
             public uint[] Convolution(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b)
-                => ConvolutionAnyMod.Convolution(a, b, (int)mod);
+                  => ConvolutionAnyMod.Convolution(a, b, (int)mod);
 
+            [凾(256)]
             public uint Calculate(long n)
             {
                 var b = new uint[a.Length];
@@ -118,6 +122,7 @@ namespace Kzrnm.Competitive
                 }
             }
 
+            [凾(256)]
             public uint[] MultiplyMod(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b)
             {
                 var beta = Convolution(a, b);
@@ -129,9 +134,11 @@ namespace Kzrnm.Competitive
                 return result;
             }
 
+            [凾(256)]
             public uint[] Convolution(ReadOnlySpan<uint> a, ReadOnlySpan<uint> b)
-                => ConvolutionAnyMod.Convolution<TMod>(a, b);
+                   => ConvolutionAnyMod.Convolution<TMod>(a, b);
 
+            [凾(256)]
             public uint Calculate(long n)
             {
                 var b = new uint[a.Length];

--- a/Competitive.Library/Math/Kitamasa.cs
+++ b/Competitive.Library/Math/Kitamasa.cs
@@ -1,11 +1,8 @@
 ﻿using AtCoder;
 using AtCoder.Internal;
 using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -15,18 +12,21 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa(uint[] a, uint[] c, long n, int mod)
-            => FastKitamasa((ReadOnlySpan<uint>)a, c, n, mod);
+             => FastKitamasa((ReadOnlySpan<uint>)a, c, n, mod);
         /// <summary>
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa(Span<uint> a, Span<uint> c, long n, int mod)
-            => FastKitamasa((ReadOnlySpan<uint>)a, c, n, mod);
+             => FastKitamasa((ReadOnlySpan<uint>)a, c, n, mod);
         /// <summary>
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa(ReadOnlySpan<uint> a, ReadOnlySpan<uint> c, long n, int mod)
         {
             Contract.Assert(a.Length == c.Length, reason: "漸化式の係数 c と数列 a の数が違います");
@@ -38,24 +38,28 @@ namespace Kzrnm.Competitive
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa<TMod>(StaticModInt<TMod>[] a, StaticModInt<TMod>[] c, long n) where TMod : struct, IStaticMod
-            => FastKitamasa<TMod>(MemoryMarshal.Cast<StaticModInt<TMod>, uint>(a), MemoryMarshal.Cast<StaticModInt<TMod>, uint>(c), n);
+             => FastKitamasa<TMod>(MemoryMarshal.Cast<StaticModInt<TMod>, uint>(a), MemoryMarshal.Cast<StaticModInt<TMod>, uint>(c), n);
         /// <summary>
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa<TMod>(uint[] a, uint[] c, long n) where TMod : struct, IStaticMod
-            => FastKitamasa<TMod>((ReadOnlySpan<uint>)a, c, n);
+             => FastKitamasa<TMod>((ReadOnlySpan<uint>)a, c, n);
         /// <summary>
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa<TMod>(Span<uint> a, Span<uint> c, long n) where TMod : struct, IStaticMod
-            => FastKitamasa<TMod>((ReadOnlySpan<uint>)a, c, n);
+             => FastKitamasa<TMod>((ReadOnlySpan<uint>)a, c, n);
         /// <summary>
         /// <para><paramref name="a"/>[n+k] = <paramref name="c"/>[0]*<paramref name="a"/>[n+k-1]+...+<paramref name="c"/>[k-1]*<paramref name="a"/>[n] である漸化式 <paramref name="a"/>(0-based) の <paramref name="n"/> を求めます。</para>
         /// <para>計算量: O(k logk logn)</para>
         /// </summary>
+        [凾(256)]
         public static uint FastKitamasa<TMod>(ReadOnlySpan<uint> a, ReadOnlySpan<uint> c, long n) where TMod : struct, IStaticMod
         {
             Contract.Assert(a.Length == c.Length, reason: "漸化式の係数 c と数列 a の数が違います");

--- a/Competitive.Library/Math/MathLibEx.cs
+++ b/Competitive.Library/Math/MathLibEx.cs
@@ -1,33 +1,33 @@
-﻿using AtCoder;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
 using System;
 using System.Numerics;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class MathLibEx
     {
         /// <summary>
         /// 最大公約数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int Gcd(int a, int b) => b > a ? Gcd(b, a) : (b == 0 ? a : Gcd(b, a % b));
         /// <summary>
         /// 最大公約数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static long Gcd(long a, long b) => b > a ? Gcd(b, a) : (b == 0 ? a : Gcd(b, a % b));
         /// <summary>
         /// 最大公約数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static BigInteger Gcd(BigInteger a, BigInteger b) => BigInteger.GreatestCommonDivisor(a, b);
 
         /// <summary>
         /// 最大公約数
         /// </summary>
+        [凾(256)]
         public static int Gcd(params int[] nums)
         {
             var gcd = nums[0];
@@ -38,6 +38,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最大公約数
         /// </summary>
+        [凾(256)]
         public static long Gcd(params long[] nums)
         {
             var gcd = nums[0];
@@ -48,6 +49,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最大公約数
         /// </summary>
+        [凾(256)]
         public static BigInteger Gcd(params BigInteger[] nums)
         {
             var gcd = nums[0];
@@ -59,22 +61,23 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最小公倍数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static int Lcm(int a, int b) => a / Gcd(a, b) * b;
         /// <summary>
         /// 最小公倍数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static long Lcm(long a, long b) => checked(a / Gcd(a, b) * b);
         /// <summary>
         /// 最小公倍数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public static BigInteger Lcm(BigInteger a, BigInteger b) => a / Gcd(a, b) * b;
 
         /// <summary>
         /// 最小公倍数
         /// </summary>
+        [凾(256)]
         public static int Lcm(params int[] nums)
         {
             var lcm = nums[0];
@@ -85,6 +88,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最小公倍数
         /// </summary>
+        [凾(256)]
         public static long Lcm(params long[] nums)
         {
             var lcm = nums[0];
@@ -95,6 +99,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 最小公倍数
         /// </summary>
+        [凾(256)]
         public static BigInteger Lcm(params BigInteger[] nums)
         {
             var lcm = nums[0];
@@ -111,8 +116,8 @@ namespace Kzrnm.Competitive
             if (n == 1)
                 return new int[] { 1 };
 
-            var left = new AtCoder.Internal.SimpleList<int>();
-            var right = new AtCoder.Internal.SimpleList<int>();
+            var left = new SimpleList<int>();
+            var right = new SimpleList<int>();
             left.Add(1);
             right.Add(n);
 
@@ -142,8 +147,8 @@ namespace Kzrnm.Competitive
             if (n == 1)
                 return new long[] { 1 };
 
-            var left = new AtCoder.Internal.SimpleList<long>();
-            var right = new AtCoder.Internal.SimpleList<long>();
+            var left = new SimpleList<long>();
+            var right = new SimpleList<long>();
             left.Add(1);
             right.Add(n);
 

--- a/Competitive.Library/Math/MathLibGeneric.cs
+++ b/Competitive.Library/Math/MathLibGeneric.cs
@@ -1,5 +1,5 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -11,8 +11,9 @@ namespace Kzrnm.Competitive
         /// <remarks>
         /// <para>計算量: O(log <paramref name="y"/>)</para>
         /// </remarks>
+        [凾(256)]
         public static T Pow<T, TOp>(T x, long y)
-            where TOp : struct, IMultiplicationOperator<T>
+              where TOp : struct, IMultiplicationOperator<T>
         {
             var op = default(TOp);
             T res = ((y & 1) != 0) ? x : op.MultiplyIdentity;

--- a/Competitive.Library/Math/Matrix/ArrayMatrix.cs
+++ b/Competitive.Library/Math/Matrix/ArrayMatrix.cs
@@ -1,14 +1,12 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using AtCoder.Operators;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public readonly struct ArrayMatrix<T, TOp>
         where TOp : struct, IArithmeticOperator<T>
     {
@@ -353,22 +351,22 @@ namespace Kzrnm.Competitive
     {
         public ArrayMatrix<T, TOp> MultiplyIdentity => ArrayMatrix<T, TOp>.Identity;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Add(ArrayMatrix<T, TOp> x, ArrayMatrix<T, TOp> y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Subtract(ArrayMatrix<T, TOp> x, ArrayMatrix<T, TOp> y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Multiply(ArrayMatrix<T, TOp> x, ArrayMatrix<T, TOp> y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Minus(ArrayMatrix<T, TOp> x) => -x;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Increment(ArrayMatrix<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Decrement(ArrayMatrix<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Divide(ArrayMatrix<T, TOp> x, ArrayMatrix<T, TOp> y) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public ArrayMatrix<T, TOp> Modulo(ArrayMatrix<T, TOp> x, ArrayMatrix<T, TOp> y) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/Matrix/Matrix2x2.cs
+++ b/Competitive.Library/Math/Matrix/Matrix2x2.cs
@@ -1,11 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public readonly struct Matrix2x2<T, TOp>
         where TOp : struct, IArithmeticOperator<T>
     {
@@ -21,18 +19,22 @@ namespace Kzrnm.Competitive
             (op.MultiplyIdentity, default(T)),
             (default(T), op.MultiplyIdentity));
 
+        [凾(256)]
         public static Matrix2x2<T, TOp> operator -(Matrix2x2<T, TOp> x)
             => new Matrix2x2<T, TOp>(
                 (op.Minus(x.Row0.Col0), op.Minus(x.Row0.Col1)),
                 (op.Minus(x.Row1.Col0), op.Minus(x.Row1.Col1)));
+        [凾(256)]
         public static Matrix2x2<T, TOp> operator +(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y)
             => new Matrix2x2<T, TOp>(
                 (op.Add(x.Row0.Col0, y.Row0.Col0), op.Add(x.Row0.Col1, y.Row0.Col1)),
                 (op.Add(x.Row1.Col0, y.Row1.Col0), op.Add(x.Row1.Col1, y.Row1.Col1)));
+        [凾(256)]
         public static Matrix2x2<T, TOp> operator -(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y)
             => new Matrix2x2<T, TOp>(
                 (op.Subtract(x.Row0.Col0, y.Row0.Col0), op.Subtract(x.Row0.Col1, y.Row0.Col1)),
                 (op.Subtract(x.Row1.Col0, y.Row1.Col0), op.Subtract(x.Row1.Col1, y.Row1.Col1)));
+        [凾(256)]
         public static Matrix2x2<T, TOp> operator *(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y)
             => new Matrix2x2<T, TOp>(
                 (
@@ -41,6 +43,7 @@ namespace Kzrnm.Competitive
                 (
                     op.Add(op.Multiply(x.Row1.Col0, y.Row0.Col0), op.Multiply(x.Row1.Col1, y.Row1.Col0)),
                     op.Add(op.Multiply(x.Row1.Col0, y.Row0.Col1), op.Multiply(x.Row1.Col1, y.Row1.Col1))));
+        [凾(256)]
         public static Matrix2x2<T, TOp> operator *(T a, Matrix2x2<T, TOp> y)
             => new Matrix2x2<T, TOp>(
                 (op.Multiply(a, y.Row0.Col0), op.Multiply(a, y.Row0.Col1)),
@@ -50,31 +53,36 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public static (T v0, T v1) operator *(Matrix2x2<T, TOp> mat, (T v0, T v1) vector) => mat.Multiply(vector);
 
         /// <summary>
         /// 2次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1) Multiply((T v0, T v1) vector) => Multiply(vector.v0, vector.v1);
 
         /// <summary>
         /// 2次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1) Multiply(T v0, T v1)
-            => (
-                    op.Add(op.Multiply(Row0.Col0, v0), op.Multiply(Row0.Col1, v1)),
-                    op.Add(op.Multiply(Row1.Col0, v0), op.Multiply(Row1.Col1, v1))
-               );
+                => (
+                        op.Add(op.Multiply(Row0.Col0, v0), op.Multiply(Row0.Col1, v1)),
+                        op.Add(op.Multiply(Row1.Col0, v0), op.Multiply(Row1.Col1, v1))
+                   );
 
         /// <summary>
         /// <paramref name="y"/> 乗した行列を返す。
         /// </summary>
+        [凾(256)]
         public Matrix2x2<T, TOp> Pow(long y) => MathLibGeneric.Pow<Matrix2x2<T, TOp>, Matrix2x2Operator<T, TOp>>(this, y);
 
 
         /// <summary>
         /// 行列式を求める
         /// </summary>
+        [凾(256)]
         public T Determinant()
         {
             return op.Subtract(op.Multiply(Row0.Col0, Row1.Col1), op.Multiply(Row0.Col1, Row1.Col0));
@@ -83,6 +91,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 逆行列を求める
         /// </summary>
+        [凾(256)]
         public Matrix2x2<T, TOp> Inv()
         {
             var det = Determinant();
@@ -99,22 +108,22 @@ namespace Kzrnm.Competitive
     {
         public Matrix2x2<T, TOp> MultiplyIdentity => Matrix2x2<T, TOp>.Identity;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Add(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Subtract(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Multiply(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Minus(Matrix2x2<T, TOp> x) => -x;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Increment(Matrix2x2<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Decrement(Matrix2x2<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Divide(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix2x2<T, TOp> Modulo(Matrix2x2<T, TOp> x, Matrix2x2<T, TOp> y) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/Matrix/Matrix3x3.cs
+++ b/Competitive.Library/Math/Matrix/Matrix3x3.cs
@@ -1,11 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public readonly struct Matrix3x3<T, TOp>
         where TOp : struct, IArithmeticOperator<T>
     {
@@ -24,21 +22,25 @@ namespace Kzrnm.Competitive
             (default(T), op.MultiplyIdentity, default(T)),
             (default(T), default(T), op.MultiplyIdentity));
 
+        [凾(256)]
         public static Matrix3x3<T, TOp> operator -(Matrix3x3<T, TOp> x)
             => new Matrix3x3<T, TOp>(
                 (op.Minus(x.Row0.Col0), op.Minus(x.Row0.Col1), op.Minus(x.Row0.Col2)),
                 (op.Minus(x.Row1.Col0), op.Minus(x.Row1.Col1), op.Minus(x.Row1.Col2)),
                 (op.Minus(x.Row2.Col0), op.Minus(x.Row2.Col1), op.Minus(x.Row2.Col2)));
+        [凾(256)]
         public static Matrix3x3<T, TOp> operator +(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y)
             => new Matrix3x3<T, TOp>(
                 (op.Add(x.Row0.Col0, y.Row0.Col0), op.Add(x.Row0.Col1, y.Row0.Col1), op.Add(x.Row0.Col2, y.Row0.Col2)),
                 (op.Add(x.Row1.Col0, y.Row1.Col0), op.Add(x.Row1.Col1, y.Row1.Col1), op.Add(x.Row1.Col2, y.Row1.Col2)),
                 (op.Add(x.Row2.Col0, y.Row2.Col0), op.Add(x.Row2.Col1, y.Row2.Col1), op.Add(x.Row2.Col2, y.Row2.Col2)));
+        [凾(256)]
         public static Matrix3x3<T, TOp> operator -(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y)
             => new Matrix3x3<T, TOp>(
                 (op.Subtract(x.Row0.Col0, y.Row0.Col0), op.Subtract(x.Row0.Col1, y.Row0.Col1), op.Subtract(x.Row0.Col2, y.Row0.Col2)),
                 (op.Subtract(x.Row1.Col0, y.Row1.Col0), op.Subtract(x.Row1.Col1, y.Row1.Col1), op.Subtract(x.Row1.Col2, y.Row1.Col2)),
                 (op.Subtract(x.Row2.Col0, y.Row2.Col0), op.Subtract(x.Row2.Col1, y.Row2.Col1), op.Subtract(x.Row2.Col2, y.Row2.Col2)));
+        [凾(256)]
         public static Matrix3x3<T, TOp> operator *(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y)
             => new Matrix3x3<T, TOp>(
                 (
@@ -57,6 +59,7 @@ namespace Kzrnm.Competitive
                     op.Add(op.Add(op.Multiply(x.Row2.Col0, y.Row0.Col2), op.Multiply(x.Row2.Col1, y.Row1.Col2)), op.Multiply(x.Row2.Col2, y.Row2.Col2))
                 )
             );
+        [凾(256)]
         public static Matrix3x3<T, TOp> operator *(T a, Matrix3x3<T, TOp> y)
             => new Matrix3x3<T, TOp>(
                 (op.Multiply(a, y.Row0.Col0), op.Multiply(a, y.Row0.Col1), op.Multiply(a, y.Row0.Col2)),
@@ -67,16 +70,19 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 3次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public static (T v0, T v1, T v2) operator *(Matrix3x3<T, TOp> mat, (T v0, T v1, T v2) vector) => mat.Multiply(vector);
 
         /// <summary>
         /// 3次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1, T v2) Multiply((T v0, T v1, T v2) vector) => Multiply(vector.v0, vector.v1, vector.v2);
 
         /// <summary>
         /// 3次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1, T v2) Multiply(T v0, T v1, T v2)
             => (
                     op.Add(op.Add(op.Multiply(Row0.Col0, v0), op.Multiply(Row0.Col1, v1)), op.Multiply(Row0.Col2, v2)),
@@ -87,11 +93,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="y"/> 乗した行列を返す。
         /// </summary>
+        [凾(256)]
         public Matrix3x3<T, TOp> Pow(long y) => MathLibGeneric.Pow<Matrix3x3<T, TOp>, Matrix3x3Operator<T, TOp>>(this, y);
 
         /// <summary>
         /// 行列式を求める
         /// </summary>
+        [凾(256)]
         public T Determinant()
         {
             return op.Subtract(
@@ -106,6 +114,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 逆行列を求める
         /// </summary>
+        [凾(256)]
         public Matrix3x3<T, TOp> Inv()
         {
             var r0c0 = op.Subtract(op.Multiply(Row1.Col1, Row2.Col2), op.Multiply(Row1.Col2, Row2.Col1));
@@ -135,22 +144,22 @@ namespace Kzrnm.Competitive
     {
         public Matrix3x3<T, TOp> MultiplyIdentity => Matrix3x3<T, TOp>.Identity;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Add(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Subtract(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Multiply(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Minus(Matrix3x3<T, TOp> x) => -x;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Increment(Matrix3x3<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Decrement(Matrix3x3<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Divide(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix3x3<T, TOp> Modulo(Matrix3x3<T, TOp> x, Matrix3x3<T, TOp> y) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/Matrix/Matrix4x4.cs
+++ b/Competitive.Library/Math/Matrix/Matrix4x4.cs
@@ -1,11 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public readonly struct Matrix4x4<T, TOp>
         where TOp : struct, IArithmeticOperator<T>
     {
@@ -27,24 +25,28 @@ namespace Kzrnm.Competitive
             (default(T), default(T), op.MultiplyIdentity, default(T)),
             (default(T), default(T), default(T), op.MultiplyIdentity));
 
+        [凾(256)]
         public static Matrix4x4<T, TOp> operator -(Matrix4x4<T, TOp> x)
             => new Matrix4x4<T, TOp>(
                 (op.Minus(x.Row0.Col0), op.Minus(x.Row0.Col1), op.Minus(x.Row0.Col2), op.Minus(x.Row0.Col3)),
                 (op.Minus(x.Row1.Col0), op.Minus(x.Row1.Col1), op.Minus(x.Row1.Col2), op.Minus(x.Row1.Col3)),
                 (op.Minus(x.Row2.Col0), op.Minus(x.Row2.Col1), op.Minus(x.Row2.Col2), op.Minus(x.Row2.Col3)),
                 (op.Minus(x.Row3.Col0), op.Minus(x.Row3.Col1), op.Minus(x.Row3.Col2), op.Minus(x.Row3.Col3)));
+        [凾(256)]
         public static Matrix4x4<T, TOp> operator +(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y)
             => new Matrix4x4<T, TOp>(
                 (op.Add(x.Row0.Col0, y.Row0.Col0), op.Add(x.Row0.Col1, y.Row0.Col1), op.Add(x.Row0.Col2, y.Row0.Col2), op.Add(x.Row0.Col3, y.Row0.Col3)),
                 (op.Add(x.Row1.Col0, y.Row1.Col0), op.Add(x.Row1.Col1, y.Row1.Col1), op.Add(x.Row1.Col2, y.Row1.Col2), op.Add(x.Row1.Col3, y.Row1.Col3)),
                 (op.Add(x.Row2.Col0, y.Row2.Col0), op.Add(x.Row2.Col1, y.Row2.Col1), op.Add(x.Row2.Col2, y.Row2.Col2), op.Add(x.Row2.Col3, y.Row2.Col3)),
                 (op.Add(x.Row3.Col0, y.Row3.Col0), op.Add(x.Row3.Col1, y.Row3.Col1), op.Add(x.Row3.Col2, y.Row3.Col2), op.Add(x.Row3.Col3, y.Row3.Col3)));
+        [凾(256)]
         public static Matrix4x4<T, TOp> operator -(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y)
             => new Matrix4x4<T, TOp>(
                 (op.Subtract(x.Row0.Col0, y.Row0.Col0), op.Subtract(x.Row0.Col1, y.Row0.Col1), op.Subtract(x.Row0.Col2, y.Row0.Col2), op.Subtract(x.Row0.Col3, y.Row0.Col3)),
                 (op.Subtract(x.Row1.Col0, y.Row1.Col0), op.Subtract(x.Row1.Col1, y.Row1.Col1), op.Subtract(x.Row1.Col2, y.Row1.Col2), op.Subtract(x.Row1.Col3, y.Row1.Col3)),
                 (op.Subtract(x.Row2.Col0, y.Row2.Col0), op.Subtract(x.Row2.Col1, y.Row2.Col1), op.Subtract(x.Row2.Col2, y.Row2.Col2), op.Subtract(x.Row2.Col3, y.Row2.Col3)),
                 (op.Subtract(x.Row3.Col0, y.Row3.Col0), op.Subtract(x.Row3.Col1, y.Row3.Col1), op.Subtract(x.Row3.Col2, y.Row3.Col2), op.Subtract(x.Row3.Col3, y.Row3.Col3)));
+        [凾(256)]
         public static Matrix4x4<T, TOp> operator *(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y)
             => new Matrix4x4<T, TOp>(
                 (
@@ -72,43 +74,49 @@ namespace Kzrnm.Competitive
                     op.Add(op.Add(op.Add(op.Multiply(x.Row3.Col0, y.Row0.Col3), op.Multiply(x.Row3.Col1, y.Row1.Col3)), op.Multiply(x.Row3.Col2, y.Row2.Col3)), op.Multiply(x.Row3.Col3, y.Row3.Col3))
                 )
             );
+        [凾(256)]
         public static Matrix4x4<T, TOp> operator *(T a, Matrix4x4<T, TOp> y)
-            => new Matrix4x4<T, TOp>(
-                (op.Multiply(a, y.Row0.Col0), op.Multiply(a, y.Row0.Col1), op.Multiply(a, y.Row0.Col2), op.Multiply(a, y.Row0.Col3)),
-                (op.Multiply(a, y.Row1.Col0), op.Multiply(a, y.Row1.Col1), op.Multiply(a, y.Row1.Col2), op.Multiply(a, y.Row1.Col3)),
-                (op.Multiply(a, y.Row2.Col0), op.Multiply(a, y.Row2.Col1), op.Multiply(a, y.Row2.Col2), op.Multiply(a, y.Row2.Col3)),
-                (op.Multiply(a, y.Row3.Col0), op.Multiply(a, y.Row3.Col1), op.Multiply(a, y.Row3.Col2), op.Multiply(a, y.Row3.Col3))
-            );
+             => new Matrix4x4<T, TOp>(
+                 (op.Multiply(a, y.Row0.Col0), op.Multiply(a, y.Row0.Col1), op.Multiply(a, y.Row0.Col2), op.Multiply(a, y.Row0.Col3)),
+                 (op.Multiply(a, y.Row1.Col0), op.Multiply(a, y.Row1.Col1), op.Multiply(a, y.Row1.Col2), op.Multiply(a, y.Row1.Col3)),
+                 (op.Multiply(a, y.Row2.Col0), op.Multiply(a, y.Row2.Col1), op.Multiply(a, y.Row2.Col2), op.Multiply(a, y.Row2.Col3)),
+                 (op.Multiply(a, y.Row3.Col0), op.Multiply(a, y.Row3.Col1), op.Multiply(a, y.Row3.Col2), op.Multiply(a, y.Row3.Col3))
+             );
 
         /// <summary>
         /// 4次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public static (T v0, T v1, T v2, T v3) operator *(Matrix4x4<T, TOp> mat, (T v0, T v1, T v2, T v3) vector) => mat.Multiply(vector);
 
         /// <summary>
         /// 4次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1, T v2, T v3) Multiply((T v0, T v1, T v2, T v3) vector) => Multiply(vector.v0, vector.v1, vector.v2, vector.v3);
 
         /// <summary>
         /// 4次元ベクトルにかける
         /// </summary>
+        [凾(256)]
         public (T v0, T v1, T v2, T v3) Multiply(T v0, T v1, T v2, T v3)
-            => (
-                    op.Add(op.Add(op.Add(op.Multiply(Row0.Col0, v0), op.Multiply(Row0.Col1, v1)), op.Multiply(Row0.Col2, v2)), op.Multiply(Row0.Col3, v3)),
-                    op.Add(op.Add(op.Add(op.Multiply(Row1.Col0, v0), op.Multiply(Row1.Col1, v1)), op.Multiply(Row1.Col2, v2)), op.Multiply(Row1.Col3, v3)),
-                    op.Add(op.Add(op.Add(op.Multiply(Row2.Col0, v0), op.Multiply(Row2.Col1, v1)), op.Multiply(Row2.Col2, v2)), op.Multiply(Row2.Col3, v3)),
-                    op.Add(op.Add(op.Add(op.Multiply(Row3.Col0, v0), op.Multiply(Row3.Col1, v1)), op.Multiply(Row3.Col2, v2)), op.Multiply(Row3.Col3, v3))
-               );
+                => (
+                        op.Add(op.Add(op.Add(op.Multiply(Row0.Col0, v0), op.Multiply(Row0.Col1, v1)), op.Multiply(Row0.Col2, v2)), op.Multiply(Row0.Col3, v3)),
+                        op.Add(op.Add(op.Add(op.Multiply(Row1.Col0, v0), op.Multiply(Row1.Col1, v1)), op.Multiply(Row1.Col2, v2)), op.Multiply(Row1.Col3, v3)),
+                        op.Add(op.Add(op.Add(op.Multiply(Row2.Col0, v0), op.Multiply(Row2.Col1, v1)), op.Multiply(Row2.Col2, v2)), op.Multiply(Row2.Col3, v3)),
+                        op.Add(op.Add(op.Add(op.Multiply(Row3.Col0, v0), op.Multiply(Row3.Col1, v1)), op.Multiply(Row3.Col2, v2)), op.Multiply(Row3.Col3, v3))
+                   );
 
         /// <summary>
         /// <paramref name="y"/> 乗した行列を返す。
         /// </summary>
+        [凾(256)]
         public Matrix4x4<T, TOp> Pow(long y) => MathLibGeneric.Pow<Matrix4x4<T, TOp>, Matrix4x4Operator<T, TOp>>(this, y);
 
         /// <summary>
         /// 行列式を求める
         /// </summary>
+        [凾(256)]
         public T Determinant()
         {
             var r0c0 = op.Subtract(
@@ -145,6 +153,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 逆行列を求める
         /// </summary>
+        [凾(256)]
         public Matrix4x4<T, TOp> Inv()
         {
             var r0c0 = op.Subtract(
@@ -275,22 +284,22 @@ namespace Kzrnm.Competitive
     {
         public Matrix4x4<T, TOp> MultiplyIdentity => Matrix4x4<T, TOp>.Identity;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Add(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y) => x + y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Subtract(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y) => x - y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Multiply(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y) => x * y;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Minus(Matrix4x4<T, TOp> x) => -x;
 
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Increment(Matrix4x4<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Decrement(Matrix4x4<T, TOp> x) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Divide(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y) => throw new NotSupportedException();
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public Matrix4x4<T, TOp> Modulo(Matrix4x4<T, TOp> x, Matrix4x4<T, TOp> y) => throw new NotSupportedException();
     }
 }

--- a/Competitive.Library/Math/NthRoots.cs
+++ b/Competitive.Library/Math/NthRoots.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -9,6 +8,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="num"/> の <paramref name="n"/> 乗根を整数に切り捨てた値
         /// </summary>
+        [凾(256)]
         public static ulong IntegerRoot(ulong num, long n)
         {
             if (num <= 1 || n == 1) return num;
@@ -24,6 +24,7 @@ namespace Kzrnm.Competitive
             }
             public readonly ulong a;
             public readonly long k;
+            [凾(256)]
             public bool Ok(ulong x)
             {
                 var y = k;

--- a/Competitive.Library/Math/Polynomial.cs
+++ b/Competitive.Library/Math/Polynomial.cs
@@ -1,6 +1,6 @@
-﻿using AtCoder;
-using AtCoder.Operators;
+﻿using AtCoder.Operators;
 using System;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -20,6 +20,7 @@ namespace Kzrnm.Competitive
         public Polynomial(T[] polynomial) { this.Coefficients = polynomial; }
 
 
+        [凾(256)]
         public static Polynomial<T, TOp> operator +(Polynomial<T, TOp> lhs, Polynomial<T, TOp> rhs)
         {
             var lp = lhs.Coefficients;
@@ -32,6 +33,7 @@ namespace Kzrnm.Competitive
             }
             return new Polynomial<T, TOp>(arr);
         }
+        [凾(256)]
         public static Polynomial<T, TOp> operator -(Polynomial<T, TOp> lhs, Polynomial<T, TOp> rhs)
         {
             var lp = lhs.Coefficients;
@@ -44,6 +46,7 @@ namespace Kzrnm.Competitive
             }
             return new Polynomial<T, TOp>(arr);
         }
+        [凾(256)]
         public static Polynomial<T, TOp> operator *(Polynomial<T, TOp> lhs, Polynomial<T, TOp> rhs)
         {
             var lp = lhs.Coefficients;
@@ -56,6 +59,7 @@ namespace Kzrnm.Competitive
 
             return new Polynomial<T, TOp>(arr);
         }
+        [凾(256)]
         public static Polynomial<T, TOp> operator *(T lhs, Polynomial<T, TOp> rhs)
         {
             var rp = rhs.Coefficients;
@@ -66,9 +70,11 @@ namespace Kzrnm.Competitive
             return new Polynomial<T, TOp>(arr);
         }
 
+        [凾(256)]
         public static Polynomial<T, TOp> operator /(Polynomial<T, TOp> lhs, Polynomial<T, TOp> rhs)
-            => lhs.DivRem(rhs, out _);
+                => lhs.DivRem(rhs, out _);
 
+        [凾(256)]
         public Polynomial<T, TOp> DivRem(Polynomial<T, TOp> rhs, out Polynomial<T, TOp> remainder)
         {
             var lp = (T[])this.Coefficients.Clone();
@@ -100,6 +106,7 @@ namespace Kzrnm.Competitive
         /// 微分した多項式を返します。
         /// </summary>
         /// <returns></returns>
+        [凾(256)]
         public Polynomial<T, TOp> Derivative()
         {
             var arr = new T[Coefficients.Length - 1];
@@ -113,6 +120,7 @@ namespace Kzrnm.Competitive
         /// 積分した多項式を返します。
         /// </summary>
         /// <returns></returns>
+        [凾(256)]
         public Polynomial<T, TOp> Integrate()
         {
             var arr = new T[Coefficients.Length + 1];
@@ -126,6 +134,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 多項式に <paramref name="x"/> を代入した値を返します。
         /// </summary>
+        [凾(256)]
         public T Calc(T x)
         {
             T x_n = x;
@@ -143,6 +152,7 @@ namespace Kzrnm.Competitive
         /// <para>(x0, y0), ..., (xn, yn)を満たす n 次多項式を返します。</para>
         /// <para>制約: xは全て異なる</para>
         /// </summary>
+        [凾(256)]
         public static Polynomial<T, TOp> LagrangeInterpolation((T x, T y)[] plots) => LagrangeInterpolation((ReadOnlySpan<(T, T)>)plots);
 
         /// <summary>
@@ -154,6 +164,7 @@ namespace Kzrnm.Competitive
         /// <para>- xは全て異なる</para>
         /// <para>計算量: O(n^2)</para>
         /// </remarks>
+        [凾(256)]
         public static Polynomial<T, TOp> LagrangeInterpolation(ReadOnlySpan<(T x, T y)> plots)
         {
             // y = ∑ (y_i * (Π_k!=i (x - x_k)) / (Π_k!=i (x_i - x_k)) )
@@ -164,6 +175,7 @@ namespace Kzrnm.Competitive
             return res;
         }
         // y_i / (Π_k!=i (x_i - x_k)) )
+        [凾(256)]
         static T ConstantCoefficient(ReadOnlySpan<(T x, T y)> plots, int i)
         {
             var (xi, yi) = plots[i];
@@ -175,6 +187,7 @@ namespace Kzrnm.Competitive
         }
 
         // Π_k (x - x_k) となる n+1 次多項式の係数
+        [凾(256)]
         static T[] PAll(ReadOnlySpan<(T x, T y)> plots)
         {
             var res = new T[plots.Length + 1];
@@ -189,6 +202,7 @@ namespace Kzrnm.Competitive
         }
 
         // Π_k!=i (x - x_k)
+        [凾(256)]
         static Polynomial<T, TOp> Pk(ReadOnlySpan<(T x, T y)> plots, int i, T[] pall)
         {
             var xi = plots[i].x;

--- a/Competitive.Library/Math/PrimeNumber.cs
+++ b/Competitive.Library/Math/PrimeNumber.cs
@@ -1,9 +1,9 @@
-﻿using AtCoder;
-using AtCoder.Internal;
+﻿using AtCoder.Internal;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -18,6 +18,7 @@ namespace Kzrnm.Competitive
         {
             (primes, searches) = Eratosthenes(max);
         }
+        [凾(256)]
         public Dictionary<long, int> PrimeFactoring(long num)
         {
             var primeFactors = new Dictionary<long, int>();
@@ -27,6 +28,7 @@ namespace Kzrnm.Competitive
             }
             return primeFactors;
         }
+        [凾(256)]
         public Dictionary<int, int> PrimeFactoring(int num)
         {
             if (num < searches.Length) return PrimeFactoringFast(num);
@@ -38,6 +40,7 @@ namespace Kzrnm.Competitive
             }
             return primeFactors;
         }
+        [凾(256)]
         IEnumerable<long> EnumerateFactor(long num)
         {
             foreach (var p in primes)
@@ -48,6 +51,7 @@ namespace Kzrnm.Competitive
             }
             if (num > 1) yield return num;
         }
+        [凾(256)]
         static bool DivIfMulti(ref long num, long p)
         {
             Math.DivRem(num, p, out var d);
@@ -58,6 +62,7 @@ namespace Kzrnm.Competitive
             }
             return false;
         }
+        [凾(256)]
         Dictionary<int, int> PrimeFactoringFast(int num)
         {
             if (num >= searches.Length) throw new ArgumentOutOfRangeException(nameof(num));
@@ -69,6 +74,7 @@ namespace Kzrnm.Competitive
             }
             return primeFactors;
         }
+        [凾(256)]
         static (int[] primes, int[] searches) Eratosthenes(int n)
         {
             var searches = new int[n + 1];
@@ -113,6 +119,7 @@ namespace Kzrnm.Competitive
         /// <para>素数かどうか判定します。</para>
         /// <para><paramref name="num"/> が <see langword="this"/> の最大の2乗より大きい場合は誤って <see langword="true"/> を返す可能性があります。</para>
         /// </summary>
+        [凾(256)]
         public bool IsPrime(long num)
         {
             if (num <= this.primes[^1])

--- a/Competitive.Library/Math/StaticModIntExtension.cs
+++ b/Competitive.Library/Math/StaticModIntExtension.cs
@@ -1,23 +1,27 @@
 ﻿using AtCoder;
 using System;
 using System.Collections.Generic;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public static class StaticModIntExtension
     {
+        [凾(256)]
         public static StaticModInt<T> Sum<T>(this IEnumerable<StaticModInt<T>> source) where T : struct, IStaticMod
         {
             ulong sum = 0;
             foreach (var v in source) sum += (ulong)v.Value;
             return new StaticModInt<T>(sum);
         }
+        [凾(256)]
         public static StaticModInt<T> Sum<T>(this ReadOnlySpan<StaticModInt<T>> source) where T : struct, IStaticMod
         {
             ulong sum = 0;
             foreach (var v in source) sum += (ulong)v.Value;
             return new StaticModInt<T>(sum);
         }
+        [凾(256)]
         public static StaticModInt<T> Sum<T>(this Span<StaticModInt<T>> source) where T : struct, IStaticMod
         {
             ulong sum = 0;

--- a/Competitive.Library/Math/StaticModIntFactor.cs
+++ b/Competitive.Library/Math/StaticModIntFactor.cs
@@ -1,9 +1,8 @@
 ﻿using AtCoder;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public class StaticModIntFactor<T> where T : struct, IStaticMod
     {
         private readonly StaticModInt<T>[] fac, finv;
@@ -21,7 +20,7 @@ namespace Kzrnm.Competitive
         }
 
         ///<summary>組み合わせ関数(二項係数)</summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> Combination(int n, int k)
         {
             if (n < k) return 0;
@@ -30,11 +29,11 @@ namespace Kzrnm.Competitive
         }
 
         ///<summary>重複組み合わせ関数</summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> Homogeneous(int n, int k) => Combination(n + k - 1, k);
 
         ///<summary>順列関数</summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> Permutation(int n, int k)
         {
             if (n < k) return 0;
@@ -45,13 +44,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="n"/> の階乗
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> Factorial(int n) => fac[n];
 
         /// <summary>
         /// <paramref name="n"/> の階乗の逆数
         /// </summary>
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> FactorialInvers(int n) => finv[n];
     }
 }

--- a/Competitive.Library/Util/Grid.cs
+++ b/Competitive.Library/Util/Grid.cs
@@ -4,31 +4,57 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
-    using static MethodImplOptions;
     public static class Grid
     {
+        [凾(256)]
         public static Grid<char> GridString(this PropertyConsoleReader cr, int H) => Create(cr.Repeat(H).Ascii);
+
+        [凾(256)]
         public static Grid<char> GridString(this PropertyConsoleReader cr, int H, char defaultValue) => Create(cr.Repeat(H).Ascii, defaultValue);
+
+        [凾(256)]
         public static Grid<int> GridInt(this PropertyConsoleReader cr, int H, int W) => Create(cr.Repeat(H).Select(cr => cr.Repeat(W).Int));
+
+        [凾(256)]
         public static Grid<int> GridInt(this PropertyConsoleReader cr, int H, int W, int defaultValue) => Create(cr.Repeat(H).Select(cr => cr.Repeat(W).Int), defaultValue);
+
+        [凾(256)]
         public static Grid<char> Create(string[] data) => new Grid<char>(data.Flatten(), data.Length, data[0].Length, default(char));
+
+        [凾(256)]
         public static Grid<char> Create(string[] data, char defaultValue) => new Grid<char>(data.Flatten(), data.Length, data[0].Length, defaultValue);
+
+        [凾(256)]
         public static Grid<T> Create<T>(T[][] data) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, default(T));
+
+        [凾(256)]
         public static Grid<T> Create<T>(T[][] data, T defaultValue) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, defaultValue);
+
+        [凾(256)]
         public static Grid<T> Create<T>(Span<T[]> data) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, default(T));
+
+        [凾(256)]
         public static Grid<T> Create<T>(Span<T[]> data, T defaultValue) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, defaultValue);
+
+        [凾(256)]
         public static Grid<T> Create<T>(ReadOnlySpan<T[]> data) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, default(T));
+
+        [凾(256)]
         public static Grid<T> Create<T>(ReadOnlySpan<T[]> data, T defaultValue) => new Grid<T>(data.Flatten(), data.Length, data[0].Length, defaultValue);
+
+        [凾(256)]
         public static void WriteGrid(this Grid<char> grid, ConsoleWriter cw)
         {
             for (int i = 0; i < grid.H; i++)
                 cw.StreamWriter.WriteLine(grid.data.AsSpan(i * grid.W, grid.W));
         }
+
+        [凾(256)]
         public static void WriteGrid<T>(this Grid<T> grid, ConsoleWriter cw)
         {
             for (int i = 0; i < grid.H; i++)
@@ -53,12 +79,12 @@ namespace Kzrnm.Competitive
             this.data = data;
             this.defaultValue = defaultValue;
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public int Index(int h, int w) =>
-            (uint)h < (uint)H && (uint)w < (uint)W
-            ? h * W + w
-            : -1;
-        [MethodImpl(AggressiveInlining)]
+    (uint)h < (uint)H && (uint)w < (uint)W
+    ? h * W + w
+    : -1;
+        [凾(256)]
         public (int h, int w) FromIndex(int ix)
         {
             var h = ix / W;
@@ -66,7 +92,7 @@ namespace Kzrnm.Competitive
         }
 
         private T defaultReference;
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         private ref T DefaultValueReference()
         {
             defaultReference = defaultValue;
@@ -74,12 +100,12 @@ namespace Kzrnm.Competitive
         }
         public ref T this[int h, int w]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get => ref this[Index(h, w)];
         }
         public ref T this[int index]
         {
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             get
             {
                 if ((uint)index < (uint)data.Length)
@@ -124,13 +150,13 @@ namespace Kzrnm.Competitive
                 return ToStringNoSplit((Grid<char>)(object)this);
             return ToStringSplit();
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public MoveEnumerator Moves(int index)
         {
             var (h, w) = FromIndex(index);
             return new MoveEnumerator(this, h, w);
         }
-        [MethodImpl(AggressiveInlining)]
+        [凾(256)]
         public MoveEnumerator Moves(int h, int w) => new MoveEnumerator(this, h, w);
         public struct MoveEnumerator : IEnumerator<(int h, int w)>, IEnumerable<(int h, int w)>
         {
@@ -145,7 +171,7 @@ namespace Kzrnm.Competitive
             private readonly Grid<T> grid;
             private readonly int origH, origW;
             private Status status;
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public MoveEnumerator(Grid<T> grid, int h, int w)
             {
                 this.grid = grid;
@@ -155,7 +181,7 @@ namespace Kzrnm.Competitive
             }
             public (int h, int w) Current
             {
-                [MethodImpl(AggressiveInlining)]
+                [凾(256)]
                 get
                 {
                     int dh = 0;
@@ -181,7 +207,7 @@ namespace Kzrnm.Competitive
 
             object IEnumerator.Current => this.Current;
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public bool MoveNext()
             {
                 switch (status)
@@ -216,7 +242,7 @@ namespace Kzrnm.Competitive
                 }
             }
 
-            [MethodImpl(AggressiveInlining)]
+            [凾(256)]
             public MoveEnumerator GetEnumerator() => this;
             IEnumerator<(int h, int w)> IEnumerable<(int h, int w)>.GetEnumerator() => this;
             IEnumerator IEnumerable.GetEnumerator() => this;

--- a/Competitive.Library/Util/IntToStaticModCastOperator.cs
+++ b/Competitive.Library/Util/IntToStaticModCastOperator.cs
@@ -1,13 +1,13 @@
 ﻿using AtCoder;
 using AtCoder.Operators;
-using System.Runtime.CompilerServices;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
     public struct IntToStaticModCastOperator<T> : ICastOperator<int, StaticModInt<T>>
            where T : struct, IStaticMod
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [凾(256)]
         public StaticModInt<T> Cast(int y) => new StaticModInt<T>(y);
     }
 }

--- a/Competitive.Library/Util/MoAlgorithm.cs
+++ b/Competitive.Library/Util/MoAlgorithm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -38,6 +38,7 @@ namespace Kzrnm.Competitive
         /// クエリの結果を返す
         /// </summary>
         /// <returns></returns>
+        [凾(256)]
         public T[] Solve()
         {
             var result = new T[Queries.Length];

--- a/Competitive.Library/Util/PointDouble.cs
+++ b/Competitive.Library/Util/PointDouble.cs
@@ -1,6 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
-using System.Net.Http.Headers;
+using System.ComponentModel;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -15,10 +16,14 @@ namespace Kzrnm.Competitive
             this.y = y;
         }
 
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [凾(256)]
         public void Deconstruct(out double v1, out double v2) { v1 = x; v2 = y; }
+        [凾(256)]
         public static implicit operator PointDouble((double x, double y) tuple) => new PointDouble(tuple.x, tuple.y);
+        [凾(256)]
         public double Distance(PointDouble other) => Math.Sqrt(Distance2(other));
+        [凾(256)]
         public double Distance2(PointDouble other)
         {
             var p = other - this;
@@ -27,13 +32,18 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 内積
         /// </summary>
+        [凾(256)]
         public double Inner(PointDouble other) => x * other.x + y * other.y;
         /// <summary>
         /// 外積
         /// </summary>
+        [凾(256)]
         public double Cross(PointDouble other) => x * other.y - y * other.x;
+        [凾(256)]
         public static PointDouble operator +(PointDouble a, PointDouble b) => new PointDouble(a.x + b.x, a.y + b.y);
+        [凾(256)]
         public static PointDouble operator -(PointDouble a, PointDouble b) => new PointDouble(a.x - b.x, a.y - b.y);
+        [凾(256)]
         public int CompareTo(PointDouble other)
         {
             var sy = Math.Sign(y);
@@ -75,6 +85,7 @@ namespace Kzrnm.Competitive
         }
         public bool IsNaN => double.IsNaN(x) || double.IsNaN(y);
 
+        [凾(256)]
         public bool Equals(PointDouble other) => this.x == other.x && this.y == other.y;
         public override bool Equals(object obj) => obj is PointDouble p && this.Equals(p);
         public override int GetHashCode() => HashCode.Combine(x, y);
@@ -83,6 +94,7 @@ namespace Kzrnm.Competitive
         public static bool operator ==(PointDouble left, PointDouble right) => left.Equals(right);
         public static bool operator !=(PointDouble left, PointDouble right) => !left.Equals(right);
 
+        [凾(256)]
         static int CrossSign(double x1, double y1, double x2, double y2) => Math.Sign(x1 * y2 - y1 * x2);
 
         /// <summary>
@@ -145,12 +157,14 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// A*x+B*y+C=0 との距離
         /// </summary>
+        [凾(256)]
         public double 直線との距離(double A, double B, double C)
             => Math.Abs(A * x + B * y + C) / Math.Sqrt(A * A + B * B);
 
         /// <summary>
         /// 2点を通る直線 A*x+B*y+C=0
         /// </summary>
+        [凾(256)]
         public (double A, double B, double C) 直線(PointDouble other)
             => (other.y - this.y, this.x - other.x, this.y * (other.x - this.x) - this.x * (other.y - this.y));
 
@@ -158,6 +172,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 2点の垂直二等分線 A*x+B*y+C=0
         /// </summary>
+        [凾(256)]
         public (double A, double B, double C) 垂直二等分線(PointDouble other)
             => (this.x - other.x, this.y - other.y, (this.x * this.x - other.x * other.x + this.y * this.y - other.y * other.y) * -.5);
 
@@ -165,21 +180,25 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// P をとおる A*x+B*y=Any の垂線
         /// </summary>
+        [凾(256)]
         public static (double A, double B, double C) 直線の垂線(double a, double b, PointDouble p) => (b, -a, b * p.x - a * p.y);
 
         /// <summary>
         /// <paramref name="x"/> での A*x+B*y+C=0 の垂線
         /// </summary>
+        [凾(256)]
         public static (double A, double B, double C) 直線の垂線をXから求める(double a, double b, double c, double x) => (b, -a, b * x - a * (c - a * x));
 
         /// <summary>
         /// <paramref name="y"/> での A*x+B*y+C=0 の垂線
         /// </summary>
+        [凾(256)]
         public static (double A, double B, double C) 直線の垂線をYから求める(double a, double b, double c, double y) => (b, -a, b * (c - a * y) - a * y);
 
         /// <summary>
         /// A*x+B*y+C=0, U*x+V*y+W=0の交点
         /// </summary>
+        [凾(256)]
         public static PointDouble 直線と直線の交点(double a, double b, double c, double u, double v, double w)
         {
             var dd = a * v - b * u;
@@ -190,6 +209,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// A*x+B*y+C=0 と Pを中心とする半径rの円の交点
         /// </summary>
+        [凾(256)]
         public static PointDouble[] 直線と円の交点(double a, double b, double c, PointDouble p, double r)
         {
             var l = a * a + b * b;
@@ -219,6 +239,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// P1 を中心とする半径 r1 の円とP2 を中心とする半径 r2 の円の交点
         /// </summary>
+        [凾(256)]
         public static PointDouble[] 円の交点(PointDouble p1, double r1, PointDouble p2, double r2)
         {
             var xx = p1.x - p2.x;
@@ -232,6 +253,7 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// <paramref name="a1"/> から <paramref name="b1"/>までの線分と<paramref name="a2"/> から <paramref name="b2"/>までの線分が交差しているか
         /// </summary>
+        [凾(256)]
         public static bool 線分が交差しているか(PointDouble a1, PointDouble b1, PointDouble a2, PointDouble b2)
         {
             var ta = (a2.x - b2.x) * (a1.y - a2.y) + (a2.y - b2.y) * (a2.x - a1.x);
@@ -245,11 +267,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 多角形の面積を求める
         /// </summary>
+        [凾(256)]
         public static double Area(PointDouble[] points) => Area2(points) / 2.0;
 
         /// <summary>
         /// 多角形の面積×2を求める
         /// </summary>
+        [凾(256)]
         public static double Area2(PointDouble[] points)
         {
             Contract.Assert(points.Length >= 3);

--- a/Competitive.Library/Util/PointInt.cs
+++ b/Competitive.Library/Util/PointInt.cs
@@ -1,5 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
+using System.ComponentModel;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -14,10 +16,18 @@ namespace Kzrnm.Competitive
             this.y = y;
         }
 
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+
+        [凾(256)]
         public void Deconstruct(out int v1, out int v2) { v1 = x; v2 = y; }
+
+        [凾(256)]
         public static implicit operator PointInt((int x, int y) tuple) => new PointInt(tuple.x, tuple.y);
+
+        [凾(256)]
         public double Distance(PointInt other) => Math.Sqrt(Distance2(other));
+
+        [凾(256)]
         public long Distance2(PointInt other)
         {
             var p = other - this;
@@ -26,13 +36,23 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 内積
         /// </summary>
+
+        [凾(256)]
         public long Inner(PointInt other) => (long)x * other.x + (long)y * other.y;
         /// <summary>
         /// 外積
         /// </summary>
+
+        [凾(256)]
         public long Cross(PointInt other) => (long)x * other.y - (long)y * other.x;
+
+        [凾(256)]
         public static PointInt operator +(PointInt a, PointInt b) => new PointInt(a.x + b.x, a.y + b.y);
+
+        [凾(256)]
         public static PointInt operator -(PointInt a, PointInt b) => new PointInt(a.x - b.x, a.y - b.y);
+
+        [凾(256)]
         public int CompareTo(PointInt other)
         {
             var sy = Math.Sign(y);
@@ -73,12 +93,17 @@ namespace Kzrnm.Competitive
             return ycmp;
         }
 
+        [凾(256)]
         public bool Equals(PointInt other) => this.x == other.x && this.y == other.y;
         public override bool Equals(object obj) => obj is PointInt p && this.Equals(p);
         public override int GetHashCode() => HashCode.Combine(x, y);
         public override string ToString() => $"{x} {y}";
 
+
+        [凾(256)]
         public static bool operator ==(PointInt left, PointInt right) => left.Equals(right);
+
+        [凾(256)]
         public static bool operator !=(PointInt left, PointInt right) => !left.Equals(right);
 
         static int CrossSign(long x1, long y1, long x2, long y2) => Math.Sign(x1 * y2 - y1 * x2);
@@ -86,6 +111,8 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 凸包(一番外側の多角形)を求める
         /// </summary>
+
+        [凾(256)]
         public static int[] ConvexHull(PointInt[] points)
         {
             Contract.Assert(points.Length >= 3);
@@ -124,11 +151,15 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 多角形の面積を求める
         /// </summary>
+
+        [凾(256)]
         public static double Area(PointInt[] points) => Area2(points) / 2.0;
 
         /// <summary>
         /// 多角形の面積×2を求める
         /// </summary>
+
+        [凾(256)]
         public static long Area2(PointInt[] points)
         {
             Contract.Assert(points.Length >= 3);

--- a/Competitive.Library/Util/PointLong.cs
+++ b/Competitive.Library/Util/PointLong.cs
@@ -1,5 +1,7 @@
 ﻿using AtCoder.Internal;
 using System;
+using System.ComponentModel;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -13,10 +15,18 @@ namespace Kzrnm.Competitive
             this.y = y;
         }
 
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+
+        [凾(256)]
         public void Deconstruct(out long v1, out long v2) { v1 = x; v2 = y; }
+
+        [凾(256)]
         public static implicit operator PointLong((long x, long y) tuple) => new PointLong(tuple.x, tuple.y);
+
+        [凾(256)]
         public double Distance(PointLong other) => Math.Sqrt(Distance2(other));
+
+        [凾(256)]
         public long Distance2(PointLong other)
         {
             var p = other - this;
@@ -25,13 +35,23 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 内積
         /// </summary>
+
+        [凾(256)]
         public long Inner(PointLong other) => x * other.x + y * other.y;
         /// <summary>
         /// 外積
         /// </summary>
+
+        [凾(256)]
         public long Cross(PointLong other) => x * other.y - y * other.x;
+
+        [凾(256)]
         public static PointLong operator +(PointLong a, PointLong b) => new PointLong(a.x + b.x, a.y + b.y);
+
+        [凾(256)]
         public static PointLong operator -(PointLong a, PointLong b) => new PointLong(a.x - b.x, a.y - b.y);
+
+        [凾(256)]
         public int CompareTo(PointLong other)
         {
             var sy = Math.Sign(y);
@@ -72,18 +92,23 @@ namespace Kzrnm.Competitive
             return ycmp;
         }
 
+
+        [凾(256)]
         public bool Equals(PointLong other) => this.x == other.x && this.y == other.y;
         public override bool Equals(object obj) => obj is PointLong p && this.Equals(p);
         public override int GetHashCode() => HashCode.Combine(x, y);
         public override string ToString() => $"{x} {y}";
 
+        [凾(256)]
         public static bool operator ==(PointLong left, PointLong right) => left.Equals(right);
+        [凾(256)]
         public static bool operator !=(PointLong left, PointLong right) => !left.Equals(right);
-        static int CrossSign(long x1, long y1, long x2, long y2) => Math.Sign(x1 * y2 - y1 * x2);
+        [凾(256)] static int CrossSign(long x1, long y1, long x2, long y2) => Math.Sign(x1 * y2 - y1 * x2);
 
         /// <summary>
         /// 凸包(一番外側の多角形)を求める
         /// </summary>
+        [凾(256)]
         public static int[] ConvexHull(PointLong[] points)
         {
             Contract.Assert(points.Length >= 2);
@@ -123,11 +148,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 多角形の面積を求める
         /// </summary>
+        [凾(256)]
         public static double Area(PointLong[] points) => Area2(points) / 2.0;
 
         /// <summary>
         /// 多角形の面積×2を求める
         /// </summary>
+        [凾(256)]
         public static long Area2(PointLong[] points)
         {
             Contract.Assert(points.Length >= 3);

--- a/Competitive.Library/Util/ZahyoCompress.cs
+++ b/Competitive.Library/Util/ZahyoCompress.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 
 namespace Kzrnm.Competitive
 {
@@ -13,33 +14,40 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 座標圧縮を行う
         /// </summary>
+        [凾(256)]
         public static ZahyoCompress<T> Create<T>(IEnumerable<T> orig) => new ZahyoCompress<T>(orig).Compress();
 
         /// <summary>
         /// 座標圧縮を行う
         /// </summary>
+        [凾(256)]
         public static ZahyoCompress<T> Create<T>(ReadOnlySpan<T> orig) => new ZahyoCompress<T>(orig).Compress();
         /// <summary>
         /// 座標圧縮を行う
         /// </summary>
+        [凾(256)]
         public static ZahyoCompress<T> Create<T>(Span<T> orig) => new ZahyoCompress<T>(orig).Compress();
         /// <summary>
         /// 座標圧縮を行う
         /// </summary>
+        [凾(256)]
         public static ZahyoCompress<T> Create<T>(T[] orig) => new ZahyoCompress<T>((ReadOnlySpan<T>)orig).Compress();
 
         /// <summary>
         /// 座標圧縮後の値に置換した配列を取得する
         /// </summary>
+        [凾(256)]
         public static int[] CompressedArray<T>(ReadOnlySpan<T> orig) => new ZahyoCompress<T>(orig).Replace(orig);
 
         /// <summary>
         /// 座標圧縮後の値に置換した配列を取得する
         /// </summary>
+        [凾(256)]
         public static int[] CompressedArray<T>(Span<T> orig) => CompressedArray((ReadOnlySpan<T>)orig);
         /// <summary>
         /// 座標圧縮後の値に置換した配列を取得する
         /// </summary>
+        [凾(256)]
         public static int[] CompressedArray<T>(T[] orig) => CompressedArray((ReadOnlySpan<T>)orig);
     }
     /// <summary>
@@ -60,6 +68,7 @@ namespace Kzrnm.Competitive
         private int version;
         private int lastCompressVesion = -1;
         private IComparer<T> lastComparer;
+        [凾(256)]
         public void Add(T item)
         {
             if (data.Add(item))
@@ -70,12 +79,14 @@ namespace Kzrnm.Competitive
         /// 登録されている値から座標圧縮する。前に呼び出されたときと異なるならば作り直す。
         /// </summary>
         /// <returns></returns>
+        [凾(256)]
         public ZahyoCompress<T> Compress() => Compress(null);
 
         /// <summary>
         /// 登録されている値から座標圧縮する。前に呼び出されたときと異なるならば作り直す。
         /// </summary>
         /// <returns></returns>
+        [凾(256)]
         public ZahyoCompress<T> Compress(IComparer<T> comparer)
         {
             if (lastCompressVesion == version
@@ -108,6 +119,7 @@ namespace Kzrnm.Competitive
 #pragma warning restore CA1819 // Properties should not return arrays
 
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [凾(256)]
         public void Deconstruct(out Dictionary<T, int> newTable, out T[] original)
         {
             newTable = NewTable;
@@ -117,11 +129,13 @@ namespace Kzrnm.Competitive
         /// <summary>
         /// 座標圧縮後の値に置換した配列を取得する
         /// </summary>
+        [凾(256)]
         public int[] Replace(T[] orig) => Replace((ReadOnlySpan<T>)orig);
 
         /// <summary>
         /// 座標圧縮後の値に置換した配列を取得する
         /// </summary>
+        [凾(256)]
         public int[] Replace(ReadOnlySpan<T> orig)
         {
             if (lastCompressVesion != version)

--- a/Competitive/Program.cs
+++ b/Competitive/Program.cs
@@ -1,4 +1,4 @@
-#region usings
+#region デフォルトの usings
 using AtCoder;
 using AtCoder.Extension;
 using Kzrnm.Competitive;
@@ -12,6 +12,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using 凾 = System.Runtime.CompilerServices.MethodImplAttribute;
 using static System.Math;
 using static Kzrnm.Competitive.BitOperationsEx;
 using static Kzrnm.Competitive.Global;
@@ -26,7 +27,7 @@ partial class Program
 {
     string YesNo(bool b) => b ? "Yes" : "No";
     const bool __ManyTestCases = false;
-    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    [凾(768)]
     private object Calc()
     {
         N = cr;


### PR DESCRIPTION
`MethodImpl` を `凾` に、`AggressiveInlining` を `256` にして短くした。
ついでに付ける場所も増やした。